### PR TITLE
fix: disallow args/flags on `pwd` for now

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -5,6 +5,7 @@ mod cd;
 mod cp_mv;
 mod exit;
 mod mkdir;
+mod pwd;
 mod rm;
 mod sleep;
 
@@ -12,5 +13,6 @@ pub use cd::*;
 pub use cp_mv::*;
 pub use exit::*;
 pub use mkdir::*;
+pub use pwd::*;
 pub use rm::*;
 pub use sleep::*;

--- a/src/commands/pwd.rs
+++ b/src/commands/pwd.rs
@@ -1,0 +1,79 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+
+use anyhow::bail;
+use anyhow::Result;
+use std::path::Path;
+
+use crate::shell_types::ExecuteResult;
+use crate::shell_types::ShellPipeWriter;
+
+use super::args::parse_arg_kinds;
+use super::args::ArgKind;
+
+pub fn pwd_command(
+  cwd: &Path,
+  args: Vec<String>,
+  mut stdout: ShellPipeWriter,
+  mut stderr: ShellPipeWriter,
+) -> ExecuteResult {
+  match parse_args(args) {
+    Ok(()) => {
+      let _ = stdout.write_line(&cwd.display().to_string());
+      ExecuteResult::from_exit_code(0)
+    }
+    Err(err) => {
+      let _ = stderr.write_line(&format!("pwd: {}", err));
+      ExecuteResult::from_exit_code(1)
+    }
+  }
+}
+
+fn parse_args(args: Vec<String>) -> Result<()> {
+  if let Some(arg) = parse_arg_kinds(&args).into_iter().next() {
+    match arg {
+      ArgKind::LongFlag(flag) => {
+        bail!("flags are currently not supported: --{}", flag)
+      }
+      ArgKind::ShortFlag(flag) => {
+        bail!("flags are currently not supported: -{}", flag)
+      }
+      ArgKind::Arg(arg) => {
+        bail!("args are currently not supported: {}", arg)
+      }
+    }
+  }
+
+  Ok(())
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+  use pretty_assertions::assert_eq;
+
+  #[test]
+  fn parses_args() {
+    assert!(parse_args(vec![]).is_ok());
+    assert_eq!(
+      parse_args(vec!["test".to_string()])
+        .err()
+        .unwrap()
+        .to_string(),
+      "args are currently not supported: test"
+    );
+    assert_eq!(
+      parse_args(vec!["--flag".to_string()])
+        .err()
+        .unwrap()
+        .to_string(),
+      "flags are currently not supported: --flag"
+    );
+    assert_eq!(
+      parse_args(vec!["-t".to_string()])
+        .err()
+        .unwrap()
+        .to_string(),
+      "flags are currently not supported: -t"
+    );
+  }
+}

--- a/src/shell_types.rs
+++ b/src/shell_types.rs
@@ -137,14 +137,6 @@ impl ExecuteResult {
   pub fn from_exit_code(exit_code: i32) -> ExecuteResult {
     ExecuteResult::Continue(exit_code, Vec::new(), Vec::new())
   }
-
-  pub fn with_stdout_text(
-    mut stdout: ShellPipeWriter,
-    text: String,
-  ) -> ExecuteResult {
-    let _ = stdout.write(&text.into_bytes());
-    ExecuteResult::Continue(0, Vec::new(), Vec::new())
-  }
 }
 
 /// Reader side of a pipe.

--- a/src/test.rs
+++ b/src/test.rs
@@ -283,6 +283,13 @@ pub async fn pwd() {
     ))
     .run()
     .await;
+
+  TestBuilder::new()
+    .command("pwd -L")
+    .assert_stderr("pwd: flags are currently not supported: -L\n")
+    .assert_exit_code(1)
+    .run()
+    .await;
 }
 
 // Basic integration tests as there are unit tests in the commands


### PR DESCRIPTION
I missed doing this on this command. We should disallow flags when using pwd until we implement them.