### PR TITLE
fix: allow escaping spaces in words

### DIFF
--- a/src/combinators.rs
+++ b/src/combinators.rs
@@ -158,6 +158,18 @@ pub fn or5<'a, O>(
   or4(a, b, c, or(d, e))
 }
 
+/// Checks for any to match.
+pub fn or6<'a, O>(
+  a: impl Fn(&'a str) -> ParseResult<'a, O>,
+  b: impl Fn(&'a str) -> ParseResult<'a, O>,
+  c: impl Fn(&'a str) -> ParseResult<'a, O>,
+  d: impl Fn(&'a str) -> ParseResult<'a, O>,
+  e: impl Fn(&'a str) -> ParseResult<'a, O>,
+  f: impl Fn(&'a str) -> ParseResult<'a, O>,
+) -> impl Fn(&'a str) -> ParseResult<'a, O> {
+  or5(a, b, c, d, or(e, f))
+}
+
 /// Returns the second value and discards the first.
 pub fn preceded<'a, First, Second>(
   first: impl Fn(&'a str) -> ParseResult<'a, First>,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -404,9 +404,7 @@ fn parse_string_or_word(input: &str) -> ParseResult<StringOrWord> {
 
 fn parse_word(input: &str) -> ParseResult<Vec<StringPart>> {
   assert(
-    parse_string_parts(|c| {
-      !c.is_whitespace() && !"*~(){}<>?|&;\"'".contains(c)
-    }),
+    parse_string_parts(ParseStringPartsMode::Word),
     |result| {
       result
         .ok()
@@ -468,7 +466,7 @@ fn parse_double_quoted_string(input: &str) -> ParseResult<Vec<StringPart>> {
   // Double quotes may have escaped
   delimited(
     char('"'),
-    parse_string_parts(|c| c != '"'),
+    parse_string_parts(ParseStringPartsMode::DoubleQuotes),
     with_failure_input(
       input,
       assert_exists(char('"'), "Expected closing double quote."),
@@ -476,8 +474,14 @@ fn parse_double_quoted_string(input: &str) -> ParseResult<Vec<StringPart>> {
   )(input)
 }
 
-pub(crate) fn parse_string_parts(
-  allow_char: impl Fn(char) -> bool + Clone,
+#[derive(Clone, Copy, PartialEq)]
+enum ParseStringPartsMode {
+  DoubleQuotes,
+  Word,
+}
+
+fn parse_string_parts(
+  mode: ParseStringPartsMode,
 ) -> impl Fn(&str) -> ParseResult<Vec<StringPart>> {
   fn parse_escaped_dollar_sign(input: &str) -> ParseResult<char> {
     or(
@@ -515,14 +519,16 @@ pub(crate) fn parse_string_parts(
   }
 
   fn first_escaped_char<'a>(
-    allow_char: impl Fn(char) -> bool,
+    mode: ParseStringPartsMode,
   ) -> impl Fn(&'a str) -> ParseResult<'a, char> {
     or5(
       parse_special_shell_var,
       parse_escaped_dollar_sign,
       parse_escaped_char('`'),
       parse_escaped_char('"'),
-      if_true(parse_escaped_char('\''), move |_| allow_char('"')),
+      if_true(parse_escaped_char('\''), move |_| {
+        mode == ParseStringPartsMode::DoubleQuotes
+      }),
     )
   }
 
@@ -533,8 +539,8 @@ pub(crate) fn parse_string_parts(
       Command(SequentialList),
     }
 
-    let (input, parts) = many0(or5(
-      map(first_escaped_char(&allow_char), PendingPart::Char),
+    let (input, parts) = many0(or6(
+      map(first_escaped_char(mode), PendingPart::Char),
       map(parse_command_substitution, PendingPart::Command),
       map(
         preceded(char('$'), parse_env_var_name),
@@ -547,7 +553,22 @@ pub(crate) fn parse_string_parts(
           "Back ticks in strings is currently not supported.",
         )
       },
-      map(if_true(next_char, |c| allow_char(*c)), PendingPart::Char),
+      // words can have escaped spaces
+      map(
+        if_true(preceded(char('\\'), char(' ')), |_| {
+          mode == ParseStringPartsMode::Word
+        }),
+        PendingPart::Char,
+      ),
+      map(
+        if_true(next_char, |&c| match mode {
+          ParseStringPartsMode::DoubleQuotes => c != '"',
+          ParseStringPartsMode::Word => {
+            !c.is_whitespace() && !"*~(){}<>?|&;\"'".contains(c)
+          }
+        }),
+        PendingPart::Char,
+      ),
     ))(input)?;
 
     let mut result = Vec::new();
@@ -1133,6 +1154,11 @@ mod test {
     run_test(parse_word, "$?", Err("$? is currently not supported."));
     run_test(parse_word, "$#", Err("$# is currently not supported."));
     run_test(parse_word, "$*", Err("$* is currently not supported."));
+    run_test(
+      parse_word,
+      "test\\ test",
+      Ok(vec![StringPart::Text("test test".to_string())]),
+    );
   }
 
   #[test]

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -475,17 +475,13 @@ async fn evaluate_args(
         let text =
           evaluate_string_parts(parts, state, stdin.clone(), stderr.clone())
             .await;
-        for part in text.split(' ') {
-          let part = part.trim();
-          if !part.is_empty() {
-            result.push(part.to_string());
-          }
-        }
+        result.extend(text);
       }
       StringOrWord::String(parts) => {
         result.push(
           evaluate_string_parts(parts, state, stdin.clone(), stderr.clone())
-            .await,
+            .await
+            .join(" "),
         );
       }
     }
@@ -499,7 +495,9 @@ async fn evaluate_string_or_word(
   stdin: ShellPipeReader,
   stderr: ShellPipeWriter,
 ) -> String {
-  evaluate_string_parts(string_or_word.into_parts(), state, stdin, stderr).await
+  evaluate_string_parts(string_or_word.into_parts(), state, stdin, stderr)
+    .await
+    .join(" ")
 }
 
 async fn evaluate_string_parts(
@@ -507,18 +505,18 @@ async fn evaluate_string_parts(
   state: &ShellState,
   stdin: ShellPipeReader,
   stderr: ShellPipeWriter,
-) -> String {
-  let mut final_text = String::new();
+) -> Vec<String> {
+  let mut result = Vec::new();
+  let mut current_text = String::new();
   for part in parts {
-    match part {
-      StringPart::Text(text) => final_text.push_str(&text),
-      StringPart::Variable(name) => {
-        if let Some(value) = state.get_var(&name) {
-          final_text.push_str(value);
-        }
+    let evaluation_result_text = match part {
+      StringPart::Text(text) => {
+        current_text.push_str(&text);
+        None
       }
-      StringPart::Command(list) => final_text.push_str(
-        &evaluate_command_substitution(
+      StringPart::Variable(name) => state.get_var(&name).map(|v| v.to_string()),
+      StringPart::Command(list) => Some(
+        evaluate_command_substitution(
           list,
           state,
           stdin.clone(),
@@ -526,9 +524,39 @@ async fn evaluate_string_parts(
         )
         .await,
       ),
+    };
+
+    // This text needs to be turned into a vector of strings.
+    // For now we do a very basic string split on whitespace, but in the future
+    // we should continue to improve this functionality.
+    if let Some(text) = evaluation_result_text {
+      let mut parts = text
+        .split(' ')
+        .map(|p| p.trim())
+        .filter(|p| !p.is_empty())
+        .collect::<Vec<_>>();
+
+      if !parts.is_empty() {
+        // append the first part to the current text
+        let first_part = parts.remove(0);
+        current_text.push_str(first_part);
+
+        // store the current text
+        result.push(current_text);
+
+        // store all the parts
+        result.extend(parts.into_iter().map(|p| p.to_string()));
+
+        // use the last part as the current text so it maybe
+        // gets appended to in the future
+        current_text = result.pop().unwrap();
+      }
     }
   }
-  final_text
+  if !current_text.is_empty() {
+    result.push(current_text);
+  }
+  result
 }
 
 async fn evaluate_command_substitution(

--- a/src/test.rs
+++ b/src/test.rs
@@ -19,6 +19,36 @@ pub async fn commands() {
     .await;
 
   TestBuilder::new()
+    .command(r#"echo "1 2   3""#)
+    .assert_stdout("1 2   3\n")
+    .run()
+    .await;
+
+  TestBuilder::new()
+    .command(r#"echo 1 2\ \ \ 3"#)
+    .assert_stdout("1 2   3\n")
+    .run()
+    .await;
+
+  TestBuilder::new()
+    .command(r#"echo "1 2\ \ \ 3""#)
+    .assert_stdout("1 2\\ \\ \\ 3\n")
+    .run()
+    .await;
+
+  TestBuilder::new()
+    .command(r#"echo test$(echo "1    2")"#)
+    .assert_stdout("test1 2\n")
+    .run()
+    .await;
+
+  TestBuilder::new()
+    .command(r#"TEST="1   2" ; echo $TEST"#)
+    .assert_stdout("1 2\n")
+    .run()
+    .await;
+
+  TestBuilder::new()
     .command(
       r#"VAR=1 deno eval 'console.log(Deno.env.get("VAR"))' && echo $VAR"#,
     )


### PR DESCRIPTION
I was investigating adding glob support and was thinking about file paths with spaces in the name. That's when I realized this functionality was broken. See the tests for examples of what's now fixed. It's not perfect still... just an incremental improvement.