### PR TITLE
refactor: fn `char` to `ch`

### DIFF
--- a/src/combinators.rs
+++ b/src/combinators.rs
@@ -40,7 +40,7 @@ impl<'a> ParseError<'a> {
 pub type ParseResult<'a, O> = Result<(&'a str, O), ParseError<'a>>;
 
 /// Recognizes a character.
-pub fn char<'a>(c: char) -> impl Fn(&'a str) -> ParseResult<'a, char> {
+pub fn ch<'a>(c: char) -> impl Fn(&'a str) -> ParseResult<'a, char> {
   if_true(next_char, move |found_char| *found_char == c)
 }
 


### PR DESCRIPTION
Using `ch` instead of `character` because its short and used a lot so easy to remember what it means.

Reason is because the `char` identifier shows up as the `char` keyword after syntax highlighting. https://github.com/denoland/deno_task_shell/pull/21/files#r830417175 -- `char` was initially used to align with nom.