### PR TITLE
fix: handle `PATHEXT` with trailing semi-colon

### DIFF
--- a/src/shell.rs
+++ b/src/shell.rs
@@ -453,7 +453,7 @@ async fn resolve_command_path(
     let command_exts = path_ext
       .split(';')
       .map(|s| s.trim().to_uppercase())
-      .filter(|s| s.is_empty())
+      .filter(|s| !s.is_empty())
       .collect::<Vec<_>>();
     if command_exts.is_empty()
       || command_exts

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -445,15 +445,21 @@ async fn resolve_command_path(
     }
   }
   let path_exts = if cfg!(windows) {
+    let uc_command_name = command_name.to_uppercase();
     let path_ext = state
       .get_var("PATHEXT")
       .map(|s| s.as_str())
       .unwrap_or(".EXE;.CMD;.BAT;.COM");
     let command_exts = path_ext
       .split(';')
-      .map(|s| s.to_string().to_uppercase())
+      .map(|s| s.trim().to_uppercase())
+      .filter(|s| s.is_empty())
       .collect::<Vec<_>>();
-    if command_exts.iter().any(|ext| command_name.ends_with(ext)) {
+    if command_exts.is_empty()
+      || command_exts
+        .iter()
+        .any(|ext| uc_command_name.ends_with(ext))
+    {
       None // use the command name as-is
     } else {
       Some(command_exts)

--- a/src/test.rs
+++ b/src/test.rs
@@ -522,6 +522,17 @@ pub async fn stdin() {
     .await;
 }
 
+#[cfg(windows)]
+#[tokio::test]
+pub async fn windows_resolve_command() {
+  // not cross platform, but still allow this
+  TestBuilder::new()
+    .command("deno.exe eval 'console.log(1)'")
+    .assert_stdout("1\n")
+    .run()
+    .await;
+}
+
 fn no_such_file_error_text() -> &'static str {
   if cfg!(windows) {
     "The system cannot find the file specified. (os error 2)"

--- a/src/test.rs
+++ b/src/test.rs
@@ -531,6 +531,14 @@ pub async fn windows_resolve_command() {
     .assert_stdout("1\n")
     .run()
     .await;
+
+  TestBuilder::new()
+    .command("deno eval 'console.log(1)'")
+    // handle trailing semi-colon
+    .env_var("PATHEXT", ".EXE;")
+    .assert_stdout("1\n")
+    .run()
+    .await;
 }
 
 fn no_such_file_error_text() -> &'static str {

--- a/src/test.rs
+++ b/src/test.rs
@@ -79,6 +79,14 @@ pub async fn commands() {
     .assert_stdout("test-dashes\n")
     .run()
     .await;
+
+  TestBuilder::new()
+    .command("deno eval 'console.log(1)'")
+    .env_var("PATH", "")
+    .assert_stderr("deno: command not found\n")
+    .assert_exit_code(1)
+    .run()
+    .await;
 }
 
 #[tokio::test]

--- a/src/test_builder.rs
+++ b/src/test_builder.rs
@@ -85,6 +85,11 @@ impl TestBuilder {
     self
   }
 
+  pub fn env_var(&mut self, name: &str, value: &str) -> &mut Self {
+    self.env_vars.insert(name.to_string(), value.to_string());
+    self
+  }
+
   pub fn file(&mut self, path: &str, text: &str) -> &mut Self {
     let temp_dir = self.ensure_temp_dir();
     fs::write(temp_dir.cwd.join(path), text).unwrap();


### PR DESCRIPTION
1. Fix case sensistive comparison which should have been case insensitive
2. Fix to handle `PATHEXT` with a trailing semi-colon

Closes #27 