### PR TITLE
fix: should not overflow attempting to parse redirect value

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.61.0"
+channel = "1.62.1"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
This was erroring parsing a git hash sometimes.