### PR TITLE
feat(breaking): fail task on async command failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,7 @@ dependencies = [
  "serde",
  "tempfile",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -225,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "monch"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350537f27a69018269e534582e2f1ec532ea7078b06485fdd4db0509bd70feb8"
+checksum = "c5e2e282addadb529bb31700f7d184797382fa2eb18384986aad78d117eaf0c4"
 
 [[package]]
 name = "num_cpus"
@@ -433,9 +434,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.20.1"
+version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
+checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
 dependencies = [
  "autocfg",
  "bytes",
@@ -443,7 +444,6 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
- "once_cell",
  "pin-project-lite",
  "signal-hook-registry",
  "tokio-macros",
@@ -459,6 +459,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,10 @@ anyhow = "1.0.55"
 futures = { version = "0.3.16", optional = true }
 path-dedot = { version = "3.0.17", optional = true }
 tokio = { version = "1", features = ["fs", "io-std", "io-util", "macros", "process", "rt-multi-thread", "sync", "time"], optional = true }
+tokio-util = "0.7.4"
 os_pipe = { version = "1.0.1", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
-monch = "0.2.0"
+monch = "0.2.1"
 
 [dev-dependencies]
 parking_lot = "0.12.0"

--- a/src/shell/commands/cp_mv.rs
+++ b/src/shell/commands/cp_mv.rs
@@ -21,10 +21,10 @@ pub async fn cp_command(
   mut stderr: ShellPipeWriter,
 ) -> ExecuteResult {
   match execute_cp(cwd, args).await {
-    Ok(()) => ExecuteResult::Continue(0, Vec::new(), Vec::new()),
+    Ok(()) => ExecuteResult::from_exit_code(0),
     Err(err) => {
       stderr.write_line(&format!("cp: {}", err)).unwrap();
-      ExecuteResult::Continue(1, Vec::new(), Vec::new())
+      ExecuteResult::from_exit_code(1)
     }
   }
 }

--- a/src/shell/commands/rm.rs
+++ b/src/shell/commands/rm.rs
@@ -2,6 +2,7 @@
 
 use anyhow::bail;
 use anyhow::Result;
+use futures::FutureExt;
 use std::io::ErrorKind;
 use std::path::Path;
 
@@ -17,10 +18,10 @@ pub async fn rm_command(
   mut stderr: ShellPipeWriter,
 ) -> ExecuteResult {
   match execute_remove(cwd, args).await {
-    Ok(()) => ExecuteResult::Continue(0, Vec::new(), Vec::new()),
+    Ok(()) => ExecuteResult::from_exit_code(0),
     Err(err) => {
       stderr.write_line(&format!("rm: {}", err)).unwrap();
-      ExecuteResult::Continue(1, Vec::new(), Vec::new())
+      ExecuteResult::from_exit_code(1)
     }
   }
 }
@@ -29,39 +30,34 @@ async fn execute_remove(cwd: &Path, args: Vec<String>) -> Result<()> {
   let flags = parse_args(args)?;
   for specified_path in &flags.paths {
     let path = cwd.join(&specified_path);
-    if flags.recursive {
+    let handle = if flags.recursive {
       if path.is_dir() {
-        if let Err(err) = tokio::fs::remove_dir_all(&path).await {
-          if err.kind() != ErrorKind::NotFound || !flags.force {
-            bail!("cannot remove '{}': {}", specified_path, err);
-          }
-        }
+        tokio::fs::remove_dir_all(&path).boxed()
       } else {
-        remove_file_or_dir(&path, specified_path, &flags).await?;
+        remove_file_or_dir(&path, &flags).boxed()
       }
     } else {
-      remove_file_or_dir(&path, specified_path, &flags).await?;
+      remove_file_or_dir(&path, &flags).boxed()
+    };
+    if let Err(err) = handle.await {
+      if err.kind() != ErrorKind::NotFound || !flags.force {
+        bail!("cannot remove '{}': {}", specified_path, err);
+      }
     }
   }
+
   Ok(())
 }
 
 async fn remove_file_or_dir(
   path: &Path,
-  specified_path: &str,
   flags: &RmFlags,
-) -> Result<()> {
-  let result = if flags.dir && path.is_dir() {
+) -> std::io::Result<()> {
+  if flags.dir && path.is_dir() {
     tokio::fs::remove_dir(path).await
   } else {
     tokio::fs::remove_file(path).await
-  };
-  if let Err(err) = result {
-    if err.kind() != ErrorKind::NotFound || !flags.force {
-      bail!("cannot remove '{}': {}", specified_path, err);
-    }
   }
-  Ok(())
 }
 
 #[derive(Default, Debug, PartialEq)]

--- a/src/shell/commands/sleep.rs
+++ b/src/shell/commands/sleep.rs
@@ -16,10 +16,10 @@ pub async fn sleep_command(
   mut stderr: ShellPipeWriter,
 ) -> ExecuteResult {
   match execute_sleep(args).await {
-    Ok(()) => ExecuteResult::Continue(0, Vec::new(), Vec::new()),
+    Ok(()) => ExecuteResult::from_exit_code(0),
     Err(err) => {
       stderr.write_line(&format!("sleep: {}", err)).unwrap();
-      ExecuteResult::Continue(1, Vec::new(), Vec::new())
+      ExecuteResult::from_exit_code(1)
     }
   }
 }


### PR DESCRIPTION
This changes async commands so that on non-zero exit code they will fail the entire task. For example:

```jsonc
// task that asynchronously starts a server and starts a watcher for the frontend 
"dev": "deno task server & deno task frontend:watch"
```

Previously when running `deno task dev`, if `deno task server` failed, the entire command would not fail, which kept in line with `sh`, but it's not very practical. This change causes `deno task dev` to fail.

To opt out, developers can add an `|| exit 0`:

```jsonc
"dev": "deno task server || exit 0 & deno task frontend:watch"
```

Closes #50