### PR TITLE
fix: revert signature to not be breaking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "monch"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfc3d6c19aa23d11fd53552627a0689b424d82f5c5e375225abb739ca2e7b84"
+checksum = "f13de1c3edc9a5b9dc3a1029f56e9ab3eba34640010aff4fc01044c42ef67afa"
 
 [[package]]
 name = "num_cpus"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ tokio = { version = "1", features = ["fs", "io-std", "io-util", "macros", "proce
 tokio-util = "0.7.4"
 os_pipe = { version = "1.0.1", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
-monch = "0.3.0"
+monch = "0.4.0"
 
 [dev-dependencies]
 parking_lot = "0.12.0"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -303,10 +303,14 @@ pub fn parse(input: &str) -> Result<SequentialList> {
           Ok(expr)
         }
       } else {
-        fail_for_trailing_input(input).into_result().map_err(|err| err.into())
+        fail_for_trailing_input(input)
+          .into_result()
+          .map_err(|err| err.into())
       }
     }
-    Err(ParseError::Backtrace) => fail_for_trailing_input(input).into_result().map_err(|err| err.into()),
+    Err(ParseError::Backtrace) => fail_for_trailing_input(input)
+      .into_result()
+      .map_err(|err| err.into()),
     Err(ParseError::Failure(e)) => e.into_result().map_err(|err| err.into()),
   }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,7 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
+use anyhow::bail;
+use anyhow::Result;
 use monch::*;
 
 // Shell grammar rules this is loosely based on:
@@ -291,21 +293,21 @@ pub enum RedirectOp {
   Append,
 }
 
-pub fn parse(input: &str) -> Result<SequentialList, String> {
+pub fn parse(input: &str) -> Result<SequentialList> {
   match parse_sequential_list(input) {
     Ok((input, expr)) => {
       if input.trim().is_empty() {
         if expr.items.is_empty() {
-          Err("Empty command.".to_string())
+          bail!("Empty command.")
         } else {
           Ok(expr)
         }
       } else {
-        fail_for_trailing_input(input).into_result()
+        fail_for_trailing_input(input).into_result().map_err(|err| err.into())
       }
     }
-    Err(ParseError::Backtrace) => fail_for_trailing_input(input).into_result(),
-    Err(ParseError::Failure(e)) => e.into_result(),
+    Err(ParseError::Backtrace) => fail_for_trailing_input(input).into_result().map_err(|err| err.into()),
+    Err(ParseError::Failure(e)) => e.into_result().map_err(|err| err.into()),
   }
 }
 
@@ -878,17 +880,17 @@ mod test {
 
   #[test]
   fn test_main() {
-    assert_eq!(parse("").err().unwrap(), "Empty command.");
+    assert_eq!(parse("").err().unwrap().to_string(), "Empty command.");
     assert_eq!(
-      parse("&& testing").err().unwrap(),
+      parse("&& testing").err().unwrap().to_string(),
       concat!("Unexpected character.\n", "  && testing\n", "  ~",),
     );
     assert_eq!(
-      parse("test { test").err().unwrap(),
+      parse("test { test").err().unwrap().to_string(),
       concat!("Unexpected character.\n", "  { test\n", "  ~",),
     );
     assert_eq!(
-      parse("cp test/* other").err().unwrap(),
+      parse("cp test/* other").err().unwrap().to_string(),
       concat!(
         "Globs are currently not supported, but will be soon.\n",
         "  * other\n",
@@ -896,7 +898,7 @@ mod test {
       ),
     );
     assert_eq!(
-      parse("cp test/? other").err().unwrap(),
+      parse("cp test/? other").err().unwrap().to_string(),
       concat!(
         "Globs are currently not supported, but will be soon.\n",
         "  ? other\n",
@@ -904,7 +906,7 @@ mod test {
       ),
     );
     assert_eq!(
-      parse("(test").err().unwrap(),
+      parse("(test").err().unwrap().to_string(),
       concat!(
         "Expected closing parenthesis on subshell.\n",
         "  (test\n",
@@ -912,11 +914,11 @@ mod test {
       ),
     );
     assert_eq!(
-      parse("cmd \"test").err().unwrap(),
+      parse("cmd \"test").err().unwrap().to_string(),
       concat!("Expected closing double quote.\n", "  \"test\n", "  ~"),
     );
     assert_eq!(
-      parse("cmd 'test").err().unwrap(),
+      parse("cmd 'test").err().unwrap().to_string(),
       concat!("Expected closing single quote.\n", "  'test\n", "  ~"),
     );
 
@@ -925,7 +927,7 @@ mod test {
     assert!(parse("command --arg=\"value\"").is_ok());
 
     assert_eq!(
-      parse("echo `echo 1`").err().unwrap(),
+      parse("echo `echo 1`").err().unwrap().to_string(),
       concat!(
         "Back ticks in strings is currently not supported.\n",
         "  `echo 1`\n",


### PR DESCRIPTION
I accidentally did a breaking change in a patch (which I've yanked), so let's revert the signature, but I will also upgrade monch again.