### PR TITLE
refactor: create `ShellCommand` trait

### DIFF
--- a/src/shell/commands/cat.rs
+++ b/src/shell/commands/cat.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
 use anyhow::Result;
 use futures::future::LocalBoxFuture;

--- a/src/shell/commands/cat.rs
+++ b/src/shell/commands/cat.rs
@@ -58,9 +58,7 @@ fn execute_cat(mut context: ShellCommandContext) -> Result<ExecuteResult> {
           }
         },
         Err(err) => {
-          context
-            .stderr
-            .write_line(&format!("cat: {path}: {err}"))?;
+          context.stderr.write_line(&format!("cat: {path}: {err}"))?;
           exit_code = 1;
         }
       }

--- a/src/shell/commands/cat.rs
+++ b/src/shell/commands/cat.rs
@@ -1,55 +1,52 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
 use anyhow::Result;
+use futures::future::LocalBoxFuture;
 use std::fs::File;
 use std::io::Read;
-use std::path::Path;
-use tokio_util::sync::CancellationToken;
 
 use crate::shell::types::ExecuteResult;
-use crate::shell::types::ShellPipeReader;
-use crate::shell::types::ShellPipeWriter;
 
 use super::args::parse_arg_kinds;
 use super::args::ArgKind;
+use super::ShellCommand;
+use super::ShellCommandContext;
 
-pub fn cat_command(
-  cwd: &Path,
-  args: Vec<String>,
-  stdin: ShellPipeReader,
-  stdout: ShellPipeWriter,
-  mut stderr: ShellPipeWriter,
-  token: CancellationToken,
-) -> ExecuteResult {
-  match execute_cat(cwd, args, stdin, stdout, stderr.clone(), token) {
-    Ok(result) => result,
-    Err(err) => {
-      let _ = stderr.write_line(&format!("cat: {}", err));
-      ExecuteResult::from_exit_code(1)
-    }
+pub struct CatCommand;
+
+impl ShellCommand for CatCommand {
+  fn execute(
+    &self,
+    context: ShellCommandContext,
+  ) -> LocalBoxFuture<'static, ExecuteResult> {
+    let mut stderr = context.stderr.clone();
+    let result = match execute_cat(context) {
+      Ok(result) => result,
+      Err(err) => {
+        let _ = stderr.write_line(&format!("cat: {}", err));
+        ExecuteResult::from_exit_code(1)
+      }
+    };
+    Box::pin(futures::future::ready(result))
   }
 }
 
-fn execute_cat(
-  cwd: &Path,
-  args: Vec<String>,
-  stdin: ShellPipeReader,
-  mut stdout: ShellPipeWriter,
-  mut stderr: ShellPipeWriter,
-  token: CancellationToken,
-) -> Result<ExecuteResult> {
-  let flags = parse_args(args)?;
+fn execute_cat(mut context: ShellCommandContext) -> Result<ExecuteResult> {
+  let flags = parse_args(context.args)?;
   let mut exit_code = 0;
   let mut buf = vec![0; 1024];
   for path in flags.paths {
     if path == "-" {
-      stdin.clone().pipe_to_sender(stdout.clone())?;
+      context
+        .stdin
+        .clone()
+        .pipe_to_sender(context.stdout.clone())?;
     } else {
       // buffered to prevent reading an entire file
       // in memory
-      match File::open(cwd.join(&path)) {
+      match File::open(context.cwd.join(&path)) {
         Ok(mut file) => loop {
-          if token.is_cancelled() {
+          if context.token.is_cancelled() {
             return Ok(ExecuteResult::for_cancellation());
           }
 
@@ -57,11 +54,13 @@ fn execute_cat(
           if size == 0 {
             break;
           } else {
-            stdout.write_all(&buf[..size])?;
+            context.stdout.write_all(&buf[..size])?;
           }
         },
         Err(err) => {
-          stderr.write_line(&format!("cat: {}: {}", path, err))?;
+          context
+            .stderr
+            .write_line(&format!("cat: {}: {}", path, err))?;
           exit_code = 1;
         }
       }

--- a/src/shell/commands/cat.rs
+++ b/src/shell/commands/cat.rs
@@ -23,7 +23,7 @@ impl ShellCommand for CatCommand {
     let result = match execute_cat(context) {
       Ok(result) => result,
       Err(err) => {
-        let _ = stderr.write_line(&format!("cat: {}", err));
+        let _ = stderr.write_line(&format!("cat: {err}"));
         ExecuteResult::from_exit_code(1)
       }
     };
@@ -60,7 +60,7 @@ fn execute_cat(mut context: ShellCommandContext) -> Result<ExecuteResult> {
         Err(err) => {
           context
             .stderr
-            .write_line(&format!("cat: {}: {}", path, err))?;
+            .write_line(&format!("cat: {path}: {err}"))?;
           exit_code = 1;
         }
       }

--- a/src/shell/commands/cd.rs
+++ b/src/shell/commands/cd.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
 use std::path::Path;
 use std::path::PathBuf;

--- a/src/shell/commands/cd.rs
+++ b/src/shell/commands/cd.rs
@@ -5,29 +5,35 @@ use std::path::PathBuf;
 
 use anyhow::bail;
 use anyhow::Result;
+use futures::future::LocalBoxFuture;
 use path_dedot::ParseDot;
 
 use crate::shell::fs_util;
 use crate::shell::types::EnvChange;
 use crate::shell::types::ExecuteResult;
-use crate::shell::types::ShellPipeWriter;
 
 use super::args::parse_arg_kinds;
 use super::args::ArgKind;
+use super::ShellCommand;
+use super::ShellCommandContext;
 
-pub fn cd_command(
-  cwd: &Path,
-  args: Vec<String>,
-  mut stderr: ShellPipeWriter,
-) -> ExecuteResult {
-  match execute_cd(cwd, args) {
-    Ok(new_dir) => {
-      ExecuteResult::Continue(0, vec![EnvChange::Cd(new_dir)], Vec::new())
-    }
-    Err(err) => {
-      stderr.write_line(&format!("cd: {}", err)).unwrap();
-      ExecuteResult::Continue(1, Vec::new(), Vec::new())
-    }
+pub struct CdCommand;
+
+impl ShellCommand for CdCommand {
+  fn execute(
+    &self,
+    mut context: ShellCommandContext,
+  ) -> LocalBoxFuture<'static, ExecuteResult> {
+    let result = match execute_cd(&context.cwd, context.args) {
+      Ok(new_dir) => {
+        ExecuteResult::Continue(0, vec![EnvChange::Cd(new_dir)], Vec::new())
+      }
+      Err(err) => {
+        context.stderr.write_line(&format!("cd: {}", err)).unwrap();
+        ExecuteResult::Continue(1, Vec::new(), Vec::new())
+      }
+    };
+    Box::pin(futures::future::ready(result))
   }
 }
 

--- a/src/shell/commands/cd.rs
+++ b/src/shell/commands/cd.rs
@@ -29,7 +29,7 @@ impl ShellCommand for CdCommand {
         ExecuteResult::Continue(0, vec![EnvChange::Cd(new_dir)], Vec::new())
       }
       Err(err) => {
-        context.stderr.write_line(&format!("cd: {}", err)).unwrap();
+        context.stderr.write_line(&format!("cd: {err}")).unwrap();
         ExecuteResult::Continue(1, Vec::new(), Vec::new())
       }
     };

--- a/src/shell/commands/cp_mv.rs
+++ b/src/shell/commands/cp_mv.rs
@@ -7,6 +7,7 @@ use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;
 use futures::future::BoxFuture;
+use futures::future::LocalBoxFuture;
 use futures::FutureExt;
 
 use crate::shell::types::ExecuteResult;
@@ -14,8 +15,28 @@ use crate::shell::types::ShellPipeWriter;
 
 use super::args::parse_arg_kinds;
 use super::args::ArgKind;
+use super::execute_with_cancellation;
+use super::ShellCommand;
+use super::ShellCommandContext;
 
-pub async fn cp_command(
+pub struct CpCommand;
+
+impl ShellCommand for CpCommand {
+  fn execute(
+    &self,
+    context: ShellCommandContext,
+  ) -> LocalBoxFuture<'static, ExecuteResult> {
+    async move {
+      execute_with_cancellation!(
+        cp_command(&context.cwd, context.args, context.stderr),
+        context.token
+      )
+    }
+    .boxed_local()
+  }
+}
+
+async fn cp_command(
   cwd: &Path,
   args: Vec<String>,
   mut stderr: ShellPipeWriter,
@@ -140,7 +161,24 @@ fn parse_cp_args(cwd: &Path, args: Vec<String>) -> Result<CpFlags> {
   })
 }
 
-pub async fn mv_command(
+pub struct MvCommand;
+
+impl ShellCommand for MvCommand {
+  fn execute(
+    &self,
+    context: ShellCommandContext,
+  ) -> LocalBoxFuture<'static, ExecuteResult> {
+    async move {
+      execute_with_cancellation!(
+        mv_command(&context.cwd, context.args, context.stderr),
+        context.token
+      )
+    }
+    .boxed_local()
+  }
+}
+
+async fn mv_command(
   cwd: &Path,
   args: Vec<String>,
   mut stderr: ShellPipeWriter,

--- a/src/shell/commands/echo.rs
+++ b/src/shell/commands/echo.rs
@@ -1,0 +1,20 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+use futures::future::LocalBoxFuture;
+
+use crate::shell::types::ExecuteResult;
+
+use super::ShellCommand;
+use super::ShellCommandContext;
+
+pub struct EchoCommand;
+
+impl ShellCommand for EchoCommand {
+  fn execute(
+    &self,
+    mut context: ShellCommandContext,
+  ) -> LocalBoxFuture<'static, ExecuteResult> {
+    let _ = context.stdout.write_line(&context.args.join(" "));
+    Box::pin(futures::future::ready(ExecuteResult::from_exit_code(0)))
+  }
+}

--- a/src/shell/commands/exit.rs
+++ b/src/shell/commands/exit.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
 use anyhow::bail;
 use anyhow::Result;

--- a/src/shell/commands/exit.rs
+++ b/src/shell/commands/exit.rs
@@ -22,10 +22,7 @@ impl ShellCommand for ExitCommand {
       Ok(code) => ExecuteResult::Exit(code, Vec::new()),
       Err(err) => {
         // even if parsing args fails `exit` always exits
-        context
-          .stderr
-          .write_line(&format!("exit: {err}"))
-          .unwrap();
+        context.stderr.write_line(&format!("exit: {err}")).unwrap();
         ExecuteResult::Exit(1, Vec::new())
       }
     };

--- a/src/shell/commands/exit.rs
+++ b/src/shell/commands/exit.rs
@@ -24,7 +24,7 @@ impl ShellCommand for ExitCommand {
         // even if parsing args fails `exit` always exits
         context
           .stderr
-          .write_line(&format!("exit: {}", err))
+          .write_line(&format!("exit: {err}"))
           .unwrap();
         ExecuteResult::Exit(1, Vec::new())
       }

--- a/src/shell/commands/export.rs
+++ b/src/shell/commands/export.rs
@@ -1,0 +1,33 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+use futures::future::LocalBoxFuture;
+
+use crate::shell::types::EnvChange;
+use crate::shell::types::ExecuteResult;
+
+use super::ShellCommand;
+use super::ShellCommandContext;
+
+pub struct ExportCommand;
+
+impl ShellCommand for ExportCommand {
+  fn execute(
+    &self,
+    context: ShellCommandContext,
+  ) -> LocalBoxFuture<'static, ExecuteResult> {
+    let mut changes = Vec::new();
+    for arg in context.args {
+      // ignore if it doesn't contain an equals
+      if let Some(equals_index) = arg.find('=') {
+        let arg_name = &arg[..equals_index];
+        let arg_value = &arg[equals_index + 1..];
+        changes.push(EnvChange::SetEnvVar(
+          arg_name.to_string(),
+          arg_value.to_string(),
+        ));
+      }
+    }
+    let result = ExecuteResult::Continue(0, changes, Vec::new());
+    Box::pin(futures::future::ready(result))
+  }
+}

--- a/src/shell/commands/mod.rs
+++ b/src/shell/commands/mod.rs
@@ -4,19 +4,136 @@ mod args;
 mod cat;
 mod cd;
 mod cp_mv;
+mod echo;
 mod exit;
+mod export;
 mod mkdir;
 mod pwd;
 mod rm;
 mod sleep;
 mod xargs;
 
-pub use cat::*;
-pub use cd::*;
-pub use cp_mv::*;
-pub use exit::*;
-pub use mkdir::*;
-pub use pwd::*;
-pub use rm::*;
-pub use sleep::*;
-pub use xargs::*;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use futures::future::LocalBoxFuture;
+use tokio_util::sync::CancellationToken;
+
+use super::types::ExecuteResult;
+use super::types::FutureExecuteResult;
+use super::types::ShellPipeReader;
+use super::types::ShellPipeWriter;
+
+pub fn builtin_commands() -> HashMap<String, Box<dyn ShellCommand>> {
+  HashMap::from([
+    (
+      "cat".to_string(),
+      Box::new(cat::CatCommand) as Box<dyn ShellCommand>,
+    ),
+    (
+      "cd".to_string(),
+      Box::new(cd::CdCommand) as Box<dyn ShellCommand>,
+    ),
+    (
+      "cp".to_string(),
+      Box::new(cp_mv::CpCommand) as Box<dyn ShellCommand>,
+    ),
+    (
+      "echo".to_string(),
+      Box::new(echo::EchoCommand) as Box<dyn ShellCommand>,
+    ),
+    (
+      "exit".to_string(),
+      Box::new(exit::ExitCommand) as Box<dyn ShellCommand>,
+    ),
+    (
+      "export".to_string(),
+      Box::new(export::ExportCommand) as Box<dyn ShellCommand>,
+    ),
+    (
+      "mkdir".to_string(),
+      Box::new(mkdir::MkdirCommand) as Box<dyn ShellCommand>,
+    ),
+    (
+      "mv".to_string(),
+      Box::new(cp_mv::MvCommand) as Box<dyn ShellCommand>,
+    ),
+    (
+      "pwd".to_string(),
+      Box::new(pwd::PwdCommand) as Box<dyn ShellCommand>,
+    ),
+    (
+      "rm".to_string(),
+      Box::new(rm::RmCommand) as Box<dyn ShellCommand>,
+    ),
+    (
+      "sleep".to_string(),
+      Box::new(sleep::SleepCommand) as Box<dyn ShellCommand>,
+    ),
+    (
+      "true".to_string(),
+      Box::new(ExitCodeCommand(0)) as Box<dyn ShellCommand>,
+    ),
+    (
+      "false".to_string(),
+      Box::new(ExitCodeCommand(1)) as Box<dyn ShellCommand>,
+    ),
+    (
+      "xargs".to_string(),
+      Box::new(xargs::XargsCommand) as Box<dyn ShellCommand>,
+    ),
+  ])
+}
+
+pub struct ShellCommandContext {
+  pub args: Vec<String>,
+  pub cwd: PathBuf,
+  pub stdin: ShellPipeReader,
+  pub stdout: ShellPipeWriter,
+  pub stderr: ShellPipeWriter,
+  pub token: CancellationToken,
+  pub execute_command_args: Box<
+    dyn FnOnce(
+      Vec<String>,
+      ShellPipeReader,
+      ShellPipeWriter,
+      ShellPipeWriter,
+    ) -> FutureExecuteResult,
+  >,
+}
+
+pub trait ShellCommand {
+  fn execute(
+    &self,
+    context: ShellCommandContext,
+  ) -> LocalBoxFuture<'static, ExecuteResult>;
+}
+
+macro_rules! execute_with_cancellation {
+  ($result_expr:expr, $token:expr) => {
+    tokio::select! {
+      result = $result_expr => {
+        result
+      },
+      _ = $token.cancelled() => {
+        ExecuteResult::for_cancellation()
+      }
+    }
+  };
+}
+
+pub(super) use execute_with_cancellation;
+
+struct ExitCodeCommand(i32);
+
+impl ShellCommand for ExitCodeCommand {
+  fn execute(
+    &self,
+    _context: ShellCommandContext,
+  ) -> LocalBoxFuture<'static, ExecuteResult> {
+    // ignores additional arguments
+    Box::pin(futures::future::ready(ExecuteResult::from_exit_code(
+      self.0,
+    )))
+  }
+}

--- a/src/shell/commands/pwd.rs
+++ b/src/shell/commands/pwd.rs
@@ -2,30 +2,35 @@
 
 use anyhow::Context;
 use anyhow::Result;
+use futures::future::LocalBoxFuture;
 use std::path::Path;
 
 use crate::shell::fs_util;
 use crate::shell::types::ExecuteResult;
-use crate::shell::types::ShellPipeWriter;
 
 use super::args::parse_arg_kinds;
 use super::args::ArgKind;
+use super::ShellCommand;
+use super::ShellCommandContext;
 
-pub fn pwd_command(
-  cwd: &Path,
-  args: Vec<String>,
-  mut stdout: ShellPipeWriter,
-  mut stderr: ShellPipeWriter,
-) -> ExecuteResult {
-  match execute_pwd(cwd, args) {
-    Ok(output) => {
-      let _ = stdout.write_line(&output);
-      ExecuteResult::from_exit_code(0)
-    }
-    Err(err) => {
-      let _ = stderr.write_line(&format!("pwd: {}", err));
-      ExecuteResult::from_exit_code(1)
-    }
+pub struct PwdCommand;
+
+impl ShellCommand for PwdCommand {
+  fn execute(
+    &self,
+    mut context: ShellCommandContext,
+  ) -> LocalBoxFuture<'static, ExecuteResult> {
+    let result = match execute_pwd(&context.cwd, context.args) {
+      Ok(output) => {
+        let _ = context.stdout.write_line(&output);
+        ExecuteResult::from_exit_code(0)
+      }
+      Err(err) => {
+        let _ = context.stderr.write_line(&format!("pwd: {}", err));
+        ExecuteResult::from_exit_code(1)
+      }
+    };
+    Box::pin(futures::future::ready(result))
   }
 }
 

--- a/src/shell/commands/pwd.rs
+++ b/src/shell/commands/pwd.rs
@@ -26,7 +26,7 @@ impl ShellCommand for PwdCommand {
         ExecuteResult::from_exit_code(0)
       }
       Err(err) => {
-        let _ = context.stderr.write_line(&format!("pwd: {}", err));
+        let _ = context.stderr.write_line(&format!("pwd: {err}"));
         ExecuteResult::from_exit_code(1)
       }
     };

--- a/src/shell/commands/pwd.rs
+++ b/src/shell/commands/pwd.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
 use anyhow::Context;
 use anyhow::Result;

--- a/src/shell/commands/xargs.rs
+++ b/src/shell/commands/xargs.rs
@@ -2,13 +2,47 @@
 
 use anyhow::bail;
 use anyhow::Result;
+use futures::future::LocalBoxFuture;
+use futures::FutureExt;
 
+use crate::shell::types::ExecuteResult;
 use crate::shell::types::ShellPipeReader;
 
 use super::args::parse_arg_kinds;
 use super::args::ArgKind;
+use super::ShellCommand;
+use super::ShellCommandContext;
 
-pub fn xargs_collect_args(
+pub struct XargsCommand;
+
+impl ShellCommand for XargsCommand {
+  fn execute(
+    &self,
+    mut context: ShellCommandContext,
+  ) -> LocalBoxFuture<'static, ExecuteResult> {
+    async move {
+      match xargs_collect_args(context.args, context.stdin.clone()) {
+        Ok(args) => {
+          // don't select on cancellation here as that will occur at a lower level
+          (context.execute_command_args)(
+            args,
+            context.stdin,
+            context.stdout,
+            context.stderr,
+          )
+          .await
+        }
+        Err(err) => {
+          let _ = context.stderr.write_line(&format!("xargs: {}", err));
+          ExecuteResult::from_exit_code(1)
+        }
+      }
+    }
+    .boxed_local()
+  }
+}
+
+fn xargs_collect_args(
   cli_args: Vec<String>,
   stdin: ShellPipeReader,
 ) -> Result<Vec<String>> {

--- a/src/shell/commands/xargs.rs
+++ b/src/shell/commands/xargs.rs
@@ -33,7 +33,7 @@ impl ShellCommand for XargsCommand {
           .await
         }
         Err(err) => {
-          let _ = context.stderr.write_line(&format!("xargs: {}", err));
+          let _ = context.stderr.write_line(&format!("xargs: {err}"));
           ExecuteResult::from_exit_code(1)
         }
       }

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
 use std::collections::HashMap;
 use std::path::Path;

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -577,7 +577,7 @@ fn execute_command_args(
         Ok(child) => child,
         Err(err) => {
           stderr
-            .write_line(&format!("Error launching '{}': {}", command_name, err))
+            .write_line(&format!("Error launching '{command_name}': {err}"))
             .unwrap();
           return ExecuteResult::Continue(1, Vec::new(), Vec::new());
         }
@@ -594,7 +594,7 @@ fn execute_command_args(
             Vec::new(),
           ),
           Err(err) => {
-            stderr.write_line(&format!("{}", err)).unwrap();
+            stderr.write_line(&format!("{err}")).unwrap();
             ExecuteResult::Continue(1, Vec::new(), Vec::new())
           }
         },
@@ -641,7 +641,7 @@ fn resolve_command_path(
   if command_name.contains('/')
     || (cfg!(windows) && command_name.contains('\\'))
   {
-    return Ok(state.cwd().join(&command_name));
+    return Ok(state.cwd().join(command_name));
   }
 
   // now search based on the current environment state
@@ -679,7 +679,7 @@ fn resolve_command_path(
     let paths = if let Some(path_exts) = &path_exts {
       let mut paths = Vec::new();
       for path_ext in path_exts {
-        paths.push(search_dir.join(format!("{}{}", command_name, path_ext)))
+        paths.push(search_dir.join(format!("{command_name}{path_ext}")))
       }
       paths
     } else {

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -25,16 +25,7 @@ use crate::parser::SequentialList;
 use crate::parser::SimpleCommand;
 use crate::parser::Word;
 use crate::parser::WordPart;
-use crate::shell::commands::cat_command;
-use crate::shell::commands::cd_command;
-use crate::shell::commands::cp_command;
-use crate::shell::commands::exit_command;
-use crate::shell::commands::mkdir_command;
-use crate::shell::commands::mv_command;
-use crate::shell::commands::pwd_command;
-use crate::shell::commands::rm_command;
-use crate::shell::commands::sleep_command;
-use crate::shell::commands::xargs_collect_args;
+use crate::shell::commands::ShellCommandContext;
 use crate::shell::types::pipe;
 use crate::shell::types::EnvChange;
 use crate::shell::types::ExecuteResult;
@@ -520,22 +511,9 @@ fn execute_command_args(
   mut args: Vec<String>,
   state: ShellState,
   stdin: ShellPipeReader,
-  mut stdout: ShellPipeWriter,
+  stdout: ShellPipeWriter,
   mut stderr: ShellPipeWriter,
 ) -> FutureExecuteResult {
-  macro_rules! execute_with_cancellation {
-    ($result_expr:expr, $token:ident) => {
-      tokio::select! {
-        result = $result_expr => {
-          result
-        },
-        _ = $token.cancelled() => {
-          ExecuteResult::for_cancellation()
-        }
-      }
-    };
-  }
-
   // requires boxing because of recursive async
   async move {
     let command_name = if args.is_empty() {
@@ -558,52 +536,20 @@ fn execute_command_args(
         ), command_name, stripped_name)
       );
       ExecuteResult::from_exit_code(1)
-    } else if command_name == "cd" {
-      let cwd = state.cwd().clone();
-      cd_command(&cwd, args, stderr)
-    } else if command_name == "exit" {
-      exit_command(args, stderr)
-    } else if command_name == "pwd" {
-      pwd_command(state.cwd(), args, stdout, stderr)
-    } else if command_name == "echo" {
-      let _ = stdout.write_line(&args.join(" "));
-      ExecuteResult::from_exit_code(0)
-    } else if command_name == "true" {
-      // ignores additional arguments
-      ExecuteResult::from_exit_code(0)
-    } else if command_name == "false" {
-      // ignores additional arguments
-      ExecuteResult::from_exit_code(1)
-    } else if command_name == "cp" {
-      let cwd = state.cwd().clone();
-      execute_with_cancellation!(cp_command(&cwd, args, stderr), token)
-    } else if command_name == "mkdir" {
-      let cwd = state.cwd().clone();
-      execute_with_cancellation!(mkdir_command(&cwd, args, stderr), token)
-    } else if command_name == "cat" {
-      let cwd = state.cwd().clone();
-      cat_command(&cwd, args, stdin, stdout, stderr, token)
-    } else if command_name == "mv" {
-      let cwd = state.cwd().clone();
-      execute_with_cancellation!(mv_command(&cwd, args, stderr), token)
-    } else if command_name == "rm" {
-      let cwd = state.cwd().clone();
-      execute_with_cancellation!(rm_command(&cwd, args, stderr), token)
-    } else if command_name == "sleep" {
-      execute_with_cancellation!(sleep_command(args, stderr), token)
-    } else if command_name == "xargs" {
-      match xargs_collect_args(args, stdin.clone()) {
-        Ok(args) => {
-          // don't select on cancellation here as that will occur at a lower level
-          execute_command_args(args, state, stdin, stdout, stderr).await
-        }
-        Err(err) => {
-          let _ = stderr.write_line(&format!("xargs: {}", err));
-          ExecuteResult::from_exit_code(1)
-        }
-      }
-    } else if command_name == "export" {
-      evaluate_export_command(args)
+    } else if let Some(command) = state.resolve_command(&command_name) {
+      let state = state.clone();
+      let command_context = ShellCommandContext {
+        args,
+        cwd: state.cwd().clone(),
+        stdin,
+        stdout,
+        stderr,
+        token,
+        execute_command_args: Box::new(move |args, stdin, stdout, stderr| {
+          execute_command_args(args, state, stdin, stdout, stderr)
+        })
+      };
+      command.execute(command_context).await
     } else {
       let command_path = match resolve_command_path(&command_name, &state, || {
         Ok(std::env::current_exe()?)
@@ -659,22 +605,6 @@ fn execute_command_args(
       }
     }
   }.boxed_local()
-}
-
-fn evaluate_export_command(args: Vec<String>) -> ExecuteResult {
-  let mut changes = Vec::new();
-  for arg in args {
-    // ignore if it doesn't contain an equals
-    if let Some(equals_index) = arg.find('=') {
-      let arg_name = &arg[..equals_index];
-      let arg_value = &arg[equals_index + 1..];
-      changes.push(EnvChange::SetEnvVar(
-        arg_name.to_string(),
-        arg_value.to_string(),
-      ));
-    }
-  }
-  ExecuteResult::Continue(0, changes, Vec::new())
 }
 
 fn resolve_command_path(


### PR DESCRIPTION
This creates a `ShellCommand` trait. In a PR after this I will expose this in the API. It should allow us to inject npm binary commands.