### PR TITLE
feat: add and expose ExecutableCommand

### DIFF
--- a/src/shell/commands/cat.rs
+++ b/src/shell/commands/cat.rs
@@ -44,9 +44,9 @@ fn execute_cat(mut context: ShellCommandContext) -> Result<ExecuteResult> {
     } else {
       // buffered to prevent reading an entire file
       // in memory
-      match File::open(context.cwd.join(&path)) {
+      match File::open(context.state.cwd().join(&path)) {
         Ok(mut file) => loop {
-          if context.token.is_cancelled() {
+          if context.state.token().is_cancelled() {
             return Ok(ExecuteResult::for_cancellation());
           }
 

--- a/src/shell/commands/cd.rs
+++ b/src/shell/commands/cd.rs
@@ -24,7 +24,7 @@ impl ShellCommand for CdCommand {
     &self,
     mut context: ShellCommandContext,
   ) -> LocalBoxFuture<'static, ExecuteResult> {
-    let result = match execute_cd(&context.cwd, context.args) {
+    let result = match execute_cd(context.state.cwd(), context.args) {
       Ok(new_dir) => {
         ExecuteResult::Continue(0, vec![EnvChange::Cd(new_dir)], Vec::new())
       }

--- a/src/shell/commands/cp_mv.rs
+++ b/src/shell/commands/cp_mv.rs
@@ -28,8 +28,8 @@ impl ShellCommand for CpCommand {
   ) -> LocalBoxFuture<'static, ExecuteResult> {
     async move {
       execute_with_cancellation!(
-        cp_command(&context.cwd, context.args, context.stderr),
-        context.token
+        cp_command(context.state.cwd(), context.args, context.stderr),
+        context.state.token()
       )
     }
     .boxed_local()
@@ -170,8 +170,8 @@ impl ShellCommand for MvCommand {
   ) -> LocalBoxFuture<'static, ExecuteResult> {
     async move {
       execute_with_cancellation!(
-        mv_command(&context.cwd, context.args, context.stderr),
-        context.token
+        mv_command(context.state.cwd(), context.args, context.stderr),
+        context.state.token()
       )
     }
     .boxed_local()

--- a/src/shell/commands/executable.rs
+++ b/src/shell/commands/executable.rs
@@ -1,0 +1,203 @@
+use std::path::PathBuf;
+
+use crate::shell::types::ShellState;
+use crate::ExecuteResult;
+use crate::ShellCommand;
+use crate::ShellCommandContext;
+use anyhow::bail;
+use anyhow::Result;
+use futures::future::LocalBoxFuture;
+use futures::FutureExt;
+
+/// Command that resolves the command name and
+/// executes it in a separate process.
+pub struct ExecutableCommand {
+  command_name: String,
+}
+
+impl ExecutableCommand {
+  pub fn new(command_name: String) -> Self {
+    Self { command_name }
+  }
+}
+
+impl ShellCommand for ExecutableCommand {
+  fn execute(
+    &self,
+    context: ShellCommandContext,
+  ) -> LocalBoxFuture<'static, ExecuteResult> {
+    let command_name = self.command_name.clone();
+    async move {
+      let mut stderr = context.stderr;
+      let command_path =
+        match resolve_command_path(&command_name, &context.state, || {
+          Ok(std::env::current_exe()?)
+        }) {
+          Ok(command_path) => command_path,
+          Err(err) => {
+            stderr.write_line(&err.to_string()).unwrap();
+            return ExecuteResult::Continue(1, Vec::new(), Vec::new());
+          }
+        };
+
+      let mut sub_command = tokio::process::Command::new(&command_path);
+      let child = sub_command
+        .current_dir(context.state.cwd())
+        .args(&context.args)
+        .env_clear()
+        .envs(context.state.env_vars())
+        .stdout(context.stdout.into_stdio())
+        .stdin(context.stdin.into_stdio())
+        .stderr(stderr.clone().into_stdio())
+        .spawn();
+
+      let mut child = match child {
+        Ok(child) => child,
+        Err(err) => {
+          stderr
+            .write_line(&format!("Error launching '{command_name}': {err}"))
+            .unwrap();
+          return ExecuteResult::Continue(1, Vec::new(), Vec::new());
+        }
+      };
+
+      // avoid deadlock since this is holding onto the pipes
+      drop(sub_command);
+
+      tokio::select! {
+        result = child.wait() => match result {
+          Ok(status) => ExecuteResult::Continue(
+            status.code().unwrap_or(1),
+            Vec::new(),
+            Vec::new(),
+          ),
+          Err(err) => {
+            stderr.write_line(&format!("{err}")).unwrap();
+            ExecuteResult::Continue(1, Vec::new(), Vec::new())
+          }
+        },
+        _ = context.state.token().cancelled() => {
+          let _ = child.kill().await;
+          ExecuteResult::for_cancellation()
+        }
+      }
+    }
+    .boxed_local()
+  }
+}
+
+fn resolve_command_path(
+  command_name: &str,
+  state: &ShellState,
+  current_exe: impl FnOnce() -> Result<PathBuf>,
+) -> Result<PathBuf> {
+  if command_name.is_empty() {
+    bail!("command name was empty");
+  }
+
+  // Special handling to use the current executable for deno.
+  // This is to ensure deno tasks that use deno work in environments
+  // that don't have deno on the path and to ensure it use the current
+  // version of deno being executed rather than the one on the path,
+  // which has caused some confusion.
+  if command_name == "deno" {
+    if let Ok(exe_path) = current_exe() {
+      // this condition exists to make the tests pass because it's not
+      // using the deno as the current executable
+      let file_stem = exe_path.file_stem().map(|s| s.to_string_lossy());
+      if file_stem.map(|s| s.to_string()) == Some("deno".to_string()) {
+        return Ok(exe_path);
+      }
+    }
+  }
+
+  // check for absolute
+  if PathBuf::from(command_name).is_absolute() {
+    return Ok(PathBuf::from(command_name));
+  }
+
+  // then relative
+  if command_name.contains('/')
+    || (cfg!(windows) && command_name.contains('\\'))
+  {
+    return Ok(state.cwd().join(command_name));
+  }
+
+  // now search based on the current environment state
+  let mut search_dirs = vec![state.cwd().clone()];
+  if let Some(path) = state.get_var("PATH") {
+    for folder in path.split(if cfg!(windows) { ';' } else { ':' }) {
+      search_dirs.push(PathBuf::from(folder));
+    }
+  }
+  let path_exts = if cfg!(windows) {
+    let uc_command_name = command_name.to_uppercase();
+    let path_ext = state
+      .get_var("PATHEXT")
+      .map(|s| s.as_str())
+      .unwrap_or(".EXE;.CMD;.BAT;.COM");
+    let command_exts = path_ext
+      .split(';')
+      .map(|s| s.trim().to_uppercase())
+      .filter(|s| !s.is_empty())
+      .collect::<Vec<_>>();
+    if command_exts.is_empty()
+      || command_exts
+        .iter()
+        .any(|ext| uc_command_name.ends_with(ext))
+    {
+      None // use the command name as-is
+    } else {
+      Some(command_exts)
+    }
+  } else {
+    None
+  };
+
+  for search_dir in search_dirs {
+    let paths = if let Some(path_exts) = &path_exts {
+      let mut paths = Vec::new();
+      for path_ext in path_exts {
+        paths.push(search_dir.join(format!("{command_name}{path_ext}")))
+      }
+      paths
+    } else {
+      vec![search_dir.join(command_name)]
+    };
+    for path in paths {
+      // don't use tokio::fs::metadata here as it was never returning
+      // in some circumstances for some reason
+      if let Ok(metadata) = std::fs::metadata(&path) {
+        if metadata.is_file() {
+          return Ok(path);
+        }
+      }
+    }
+  }
+
+  bail!("{}: command not found", command_name)
+}
+
+#[cfg(test)]
+mod local_test {
+  use super::*;
+
+  #[test]
+  fn should_resolve_current_exe_path_for_deno() {
+    let state = ShellState::new(
+      Default::default(),
+      &std::env::current_dir().unwrap(),
+      Default::default(),
+    );
+    let path =
+      resolve_command_path("deno", &state, || Ok(PathBuf::from("/bin/deno")))
+        .unwrap();
+    assert_eq!(path, PathBuf::from("/bin/deno"));
+
+    let path = resolve_command_path("deno", &state, || {
+      Ok(PathBuf::from("/bin/deno.exe"))
+    })
+    .unwrap();
+    assert_eq!(path, PathBuf::from("/bin/deno.exe"));
+  }
+}

--- a/src/shell/commands/mkdir.rs
+++ b/src/shell/commands/mkdir.rs
@@ -24,8 +24,8 @@ impl ShellCommand for MkdirCommand {
   ) -> LocalBoxFuture<'static, ExecuteResult> {
     async move {
       execute_with_cancellation!(
-        mkdir_command(&context.cwd, context.args, context.stderr),
-        context.token
+        mkdir_command(context.state.cwd(), context.args, context.stderr),
+        context.state.token()
       )
     }
     .boxed_local()

--- a/src/shell/commands/mod.rs
+++ b/src/shell/commands/mod.rs
@@ -101,7 +101,6 @@ pub struct ShellCommandContext {
   pub stdin: ShellPipeReader,
   pub stdout: ShellPipeWriter,
   pub stderr: ShellPipeWriter,
-  #[allow(clippy::type_complexity)]
   pub execute_command_args:
     Box<dyn FnOnce(ExecuteCommandArgsContext) -> FutureExecuteResult>,
 }

--- a/src/shell/commands/mod.rs
+++ b/src/shell/commands/mod.rs
@@ -15,6 +15,7 @@ mod sleep;
 mod xargs;
 
 use std::collections::HashMap;
+use std::rc::Rc;
 
 use futures::future::LocalBoxFuture;
 
@@ -26,63 +27,63 @@ use super::types::ShellPipeReader;
 use super::types::ShellPipeWriter;
 use super::types::ShellState;
 
-pub fn builtin_commands() -> HashMap<String, Box<dyn ShellCommand>> {
+pub fn builtin_commands() -> HashMap<String, Rc<dyn ShellCommand>> {
   HashMap::from([
     (
       "cat".to_string(),
-      Box::new(cat::CatCommand) as Box<dyn ShellCommand>,
+      Rc::new(cat::CatCommand) as Rc<dyn ShellCommand>,
     ),
     (
       "cd".to_string(),
-      Box::new(cd::CdCommand) as Box<dyn ShellCommand>,
+      Rc::new(cd::CdCommand) as Rc<dyn ShellCommand>,
     ),
     (
       "cp".to_string(),
-      Box::new(cp_mv::CpCommand) as Box<dyn ShellCommand>,
+      Rc::new(cp_mv::CpCommand) as Rc<dyn ShellCommand>,
     ),
     (
       "echo".to_string(),
-      Box::new(echo::EchoCommand) as Box<dyn ShellCommand>,
+      Rc::new(echo::EchoCommand) as Rc<dyn ShellCommand>,
     ),
     (
       "exit".to_string(),
-      Box::new(exit::ExitCommand) as Box<dyn ShellCommand>,
+      Rc::new(exit::ExitCommand) as Rc<dyn ShellCommand>,
     ),
     (
       "export".to_string(),
-      Box::new(export::ExportCommand) as Box<dyn ShellCommand>,
+      Rc::new(export::ExportCommand) as Rc<dyn ShellCommand>,
     ),
     (
       "mkdir".to_string(),
-      Box::new(mkdir::MkdirCommand) as Box<dyn ShellCommand>,
+      Rc::new(mkdir::MkdirCommand) as Rc<dyn ShellCommand>,
     ),
     (
       "mv".to_string(),
-      Box::new(cp_mv::MvCommand) as Box<dyn ShellCommand>,
+      Rc::new(cp_mv::MvCommand) as Rc<dyn ShellCommand>,
     ),
     (
       "pwd".to_string(),
-      Box::new(pwd::PwdCommand) as Box<dyn ShellCommand>,
+      Rc::new(pwd::PwdCommand) as Rc<dyn ShellCommand>,
     ),
     (
       "rm".to_string(),
-      Box::new(rm::RmCommand) as Box<dyn ShellCommand>,
+      Rc::new(rm::RmCommand) as Rc<dyn ShellCommand>,
     ),
     (
       "sleep".to_string(),
-      Box::new(sleep::SleepCommand) as Box<dyn ShellCommand>,
+      Rc::new(sleep::SleepCommand) as Rc<dyn ShellCommand>,
     ),
     (
       "true".to_string(),
-      Box::new(ExitCodeCommand(0)) as Box<dyn ShellCommand>,
+      Rc::new(ExitCodeCommand(0)) as Rc<dyn ShellCommand>,
     ),
     (
       "false".to_string(),
-      Box::new(ExitCodeCommand(1)) as Box<dyn ShellCommand>,
+      Rc::new(ExitCodeCommand(1)) as Rc<dyn ShellCommand>,
     ),
     (
       "xargs".to_string(),
-      Box::new(xargs::XargsCommand) as Box<dyn ShellCommand>,
+      Rc::new(xargs::XargsCommand) as Rc<dyn ShellCommand>,
     ),
   ])
 }

--- a/src/shell/commands/pwd.rs
+++ b/src/shell/commands/pwd.rs
@@ -20,7 +20,7 @@ impl ShellCommand for PwdCommand {
     &self,
     mut context: ShellCommandContext,
   ) -> LocalBoxFuture<'static, ExecuteResult> {
-    let result = match execute_pwd(&context.cwd, context.args) {
+    let result = match execute_pwd(context.state.cwd(), context.args) {
       Ok(output) => {
         let _ = context.stdout.write_line(&output);
         ExecuteResult::from_exit_code(0)

--- a/src/shell/commands/rm.rs
+++ b/src/shell/commands/rm.rs
@@ -25,8 +25,8 @@ impl ShellCommand for RmCommand {
   ) -> LocalBoxFuture<'static, ExecuteResult> {
     async move {
       execute_with_cancellation!(
-        rm_command(&context.cwd, context.args, context.stderr),
-        context.token
+        rm_command(context.state.cwd(), context.args, context.stderr),
+        context.state.token()
       )
     }
     .boxed_local()

--- a/src/shell/commands/sleep.rs
+++ b/src/shell/commands/sleep.rs
@@ -26,7 +26,7 @@ impl ShellCommand for SleepCommand {
     async move {
       execute_with_cancellation!(
         sleep_command(context.args, context.stderr),
-        context.token
+        context.state.token()
       )
     }
     .boxed_local()

--- a/src/shell/commands/xargs.rs
+++ b/src/shell/commands/xargs.rs
@@ -7,6 +7,7 @@ use futures::FutureExt;
 
 use crate::shell::types::ExecuteResult;
 use crate::shell::types::ShellPipeReader;
+use crate::ExecuteCommandArgsContext;
 
 use super::args::parse_arg_kinds;
 use super::args::ArgKind;
@@ -24,12 +25,13 @@ impl ShellCommand for XargsCommand {
       match xargs_collect_args(context.args, context.stdin.clone()) {
         Ok(args) => {
           // don't select on cancellation here as that will occur at a lower level
-          (context.execute_command_args)(
+          (context.execute_command_args)(ExecuteCommandArgsContext {
             args,
-            context.stdin,
-            context.stdout,
-            context.stderr,
-          )
+            state: context.state,
+            stdin: context.stdin,
+            stdout: context.stdout,
+            stderr: context.stderr,
+          })
           .await
         }
         Err(err) => {

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -13,6 +13,11 @@ use tokio_util::sync::CancellationToken;
 
 pub use crate::shell::commands::ShellCommand;
 pub use crate::shell::commands::ShellCommandContext;
+pub use crate::shell::types::EnvChange;
+pub use crate::shell::types::ExecuteResult;
+pub use crate::shell::types::FutureExecuteResult;
+pub use crate::shell::types::ShellPipeReader;
+pub use crate::shell::types::ShellPipeWriter;
 
 use crate::parser::Command;
 use crate::parser::CommandInner;
@@ -29,11 +34,6 @@ use crate::parser::SimpleCommand;
 use crate::parser::Word;
 use crate::parser::WordPart;
 use crate::shell::types::pipe;
-use crate::shell::types::EnvChange;
-use crate::shell::types::ExecuteResult;
-use crate::shell::types::FutureExecuteResult;
-use crate::shell::types::ShellPipeReader;
-use crate::shell::types::ShellPipeWriter;
 use crate::shell::types::ShellState;
 
 use self::types::CANCELLATION_EXIT_CODE;

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -2,15 +2,16 @@
 
 use std::collections::HashMap;
 use std::path::Path;
-use std::path::PathBuf;
 
-use anyhow::bail;
 use anyhow::Result;
+use futures::future;
 use futures::future::LocalBoxFuture;
 use futures::FutureExt;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
+pub use crate::shell::commands::ExecutableCommand;
+pub use crate::shell::commands::ExecuteCommandArgsContext;
 pub use crate::shell::commands::ShellCommand;
 pub use crate::shell::commands::ShellCommandContext;
 pub use crate::shell::types::EnvChange;
@@ -18,6 +19,7 @@ pub use crate::shell::types::ExecuteResult;
 pub use crate::shell::types::FutureExecuteResult;
 pub use crate::shell::types::ShellPipeReader;
 pub use crate::shell::types::ShellPipeWriter;
+pub use crate::shell::types::ShellState;
 
 use crate::parser::Command;
 use crate::parser::CommandInner;
@@ -34,7 +36,6 @@ use crate::parser::SimpleCommand;
 use crate::parser::Word;
 use crate::parser::WordPart;
 use crate::shell::types::pipe;
-use crate::shell::types::ShellState;
 
 use self::types::CANCELLATION_EXIT_CODE;
 
@@ -114,7 +115,7 @@ fn execute_sequential_list(
         let stdout = stdout.clone();
         let stderr = stderr.clone();
         async_handles.push(tokio::task::spawn_local(async move {
-          let main_token = state.token();
+          let main_token = state.token().clone();
           let result =
             execute_sequence(item.sequence, state, stdin, stdout, stderr).await;
           let (exit_code, handles) = result.into_exit_code_and_handles();
@@ -152,7 +153,7 @@ fn execute_sequential_list(
       final_exit_code = wait_handles(
         final_exit_code,
         async_handles.drain(..).collect(),
-        state.token(),
+        state.token().clone(),
       )
       .await;
     }
@@ -513,19 +514,15 @@ fn execute_command_args(
   stdout: ShellPipeWriter,
   mut stderr: ShellPipeWriter,
 ) -> FutureExecuteResult {
-  // requires boxing because of recursive async
-  async move {
-    let command_name = if args.is_empty() {
-      String::new()
-    } else {
-      args.remove(0)
-    };
-    let token = state.token();
-    if token.is_cancelled() {
-      return ExecuteResult::for_cancellation();
-    }
-    if let Some(stripped_name) = command_name.strip_prefix('!') {
-      let _ = stderr.write_line(
+  let command_name = if args.is_empty() {
+    String::new()
+  } else {
+    args.remove(0)
+  };
+  if state.token().is_cancelled() {
+    Box::pin(future::ready(ExecuteResult::for_cancellation()))
+  } else if let Some(stripped_name) = command_name.strip_prefix('!') {
+    let _ = stderr.write_line(
         &format!(concat!(
           "History expansion is not supported:\n",
           "  {}\n",
@@ -534,168 +531,30 @@ fn execute_command_args(
           "  ! {}",
         ), command_name, stripped_name)
       );
-      ExecuteResult::from_exit_code(1)
-    } else if let Some(command) = state.resolve_command(&command_name) {
-      let state = state.clone();
-      let command_context = ShellCommandContext {
-        args,
-        cwd: state.cwd().clone(),
-        stdin,
-        stdout,
-        stderr,
-        token,
-        execute_command_args: Box::new(move |args, stdin, stdout, stderr| {
-          execute_command_args(args, state, stdin, stdout, stderr)
-        })
-      };
-      command.execute(command_context).await
-    } else {
-      let command_path = match resolve_command_path(&command_name, &state, || {
-        Ok(std::env::current_exe()?)
-      })
-      {
-        Ok(command_path) => command_path,
-        Err(err) => {
-          stderr.write_line(&err.to_string()).unwrap();
-          return ExecuteResult::Continue(1, Vec::new(), Vec::new());
-        }
-      };
-
-      let mut sub_command = tokio::process::Command::new(&command_path);
-      let child = sub_command
-        .current_dir(state.cwd())
-        .args(&args)
-        .env_clear()
-        .envs(state.env_vars())
-        .stdout(stdout.into_stdio())
-        .stdin(stdin.into_stdio())
-        .stderr(stderr.clone().into_stdio())
-        .spawn();
-
-      let mut child = match child {
-        Ok(child) => child,
-        Err(err) => {
-          stderr
-            .write_line(&format!("Error launching '{command_name}': {err}"))
-            .unwrap();
-          return ExecuteResult::Continue(1, Vec::new(), Vec::new());
-        }
-      };
-
-      // avoid deadlock since this is holding onto the pipes
-      drop(sub_command);
-
-      tokio::select! {
-        result = child.wait() => match result {
-          Ok(status) => ExecuteResult::Continue(
-            status.code().unwrap_or(1),
-            Vec::new(),
-            Vec::new(),
-          ),
-          Err(err) => {
-            stderr.write_line(&format!("{err}")).unwrap();
-            ExecuteResult::Continue(1, Vec::new(), Vec::new())
-          }
-        },
-        _ = token.cancelled() => {
-          let _ = child.kill().await;
-          ExecuteResult::for_cancellation()
-        }
-      }
-    }
-  }.boxed_local()
-}
-
-fn resolve_command_path(
-  command_name: &str,
-  state: &ShellState,
-  current_exe: impl FnOnce() -> Result<PathBuf>,
-) -> Result<PathBuf> {
-  if command_name.is_empty() {
-    bail!("command name was empty");
-  }
-
-  // Special handling to use the current executable for deno.
-  // This is to ensure deno tasks that use deno work in environments
-  // that don't have deno on the path and to ensure it use the current
-  // version of deno being executed rather than the one on the path,
-  // which has caused some confusion.
-  if command_name == "deno" {
-    if let Ok(exe_path) = current_exe() {
-      // this condition exists to make the tests pass because it's not
-      // using the deno as the current executable
-      let file_stem = exe_path.file_stem().map(|s| s.to_string_lossy());
-      if file_stem.map(|s| s.to_string()) == Some("deno".to_string()) {
-        return Ok(exe_path);
-      }
-    }
-  }
-
-  // check for absolute
-  if PathBuf::from(command_name).is_absolute() {
-    return Ok(PathBuf::from(command_name));
-  }
-
-  // then relative
-  if command_name.contains('/')
-    || (cfg!(windows) && command_name.contains('\\'))
-  {
-    return Ok(state.cwd().join(command_name));
-  }
-
-  // now search based on the current environment state
-  let mut search_dirs = vec![state.cwd().clone()];
-  if let Some(path) = state.get_var("PATH") {
-    for folder in path.split(if cfg!(windows) { ';' } else { ':' }) {
-      search_dirs.push(PathBuf::from(folder));
-    }
-  }
-  let path_exts = if cfg!(windows) {
-    let uc_command_name = command_name.to_uppercase();
-    let path_ext = state
-      .get_var("PATHEXT")
-      .map(|s| s.as_str())
-      .unwrap_or(".EXE;.CMD;.BAT;.COM");
-    let command_exts = path_ext
-      .split(';')
-      .map(|s| s.trim().to_uppercase())
-      .filter(|s| !s.is_empty())
-      .collect::<Vec<_>>();
-    if command_exts.is_empty()
-      || command_exts
-        .iter()
-        .any(|ext| uc_command_name.ends_with(ext))
-    {
-      None // use the command name as-is
-    } else {
-      Some(command_exts)
-    }
+    Box::pin(future::ready(ExecuteResult::from_exit_code(1)))
   } else {
-    None
-  };
-
-  for search_dir in search_dirs {
-    let paths = if let Some(path_exts) = &path_exts {
-      let mut paths = Vec::new();
-      for path_ext in path_exts {
-        paths.push(search_dir.join(format!("{command_name}{path_ext}")))
-      }
-      paths
-    } else {
-      vec![search_dir.join(command_name)]
+    let command_context = ShellCommandContext {
+      args,
+      state: state.clone(),
+      stdin,
+      stdout,
+      stderr,
+      execute_command_args: Box::new(move |context| {
+        execute_command_args(
+          context.args,
+          context.state,
+          context.stdin,
+          context.stdout,
+          context.stderr,
+        )
+      }),
     };
-    for path in paths {
-      // don't use tokio::fs::metadata here as it was never returning
-      // in some circumstances for some reason
-      if let Ok(metadata) = std::fs::metadata(&path) {
-        if metadata.is_file() {
-          return Ok(path);
-        }
-      }
+    if let Some(command) = state.resolve_command(&command_name) {
+      command.execute(command_context)
+    } else {
+      ExecutableCommand::new(command_name).execute(command_context)
     }
   }
-
-  bail!("{}: command not found", command_name)
 }
 
 async fn evaluate_args(
@@ -845,28 +704,4 @@ async fn execute_with_stdout_as_text(
   let _ = spawned_output.await;
   let data = output_handle.await.unwrap();
   String::from_utf8_lossy(&data).to_string()
-}
-
-#[cfg(test)]
-mod local_test {
-  use super::*;
-
-  #[test]
-  fn should_resolve_current_exe_path_for_deno() {
-    let state = ShellState::new(
-      Default::default(),
-      &std::env::current_dir().unwrap(),
-      Default::default(),
-    );
-    let path =
-      resolve_command_path("deno", &state, || Ok(PathBuf::from("/bin/deno")))
-        .unwrap();
-    assert_eq!(path, PathBuf::from("/bin/deno"));
-
-    let path = resolve_command_path("deno", &state, || {
-      Ok(PathBuf::from("/bin/deno.exe"))
-    })
-    .unwrap();
-    assert_eq!(path, PathBuf::from("/bin/deno.exe"));
-  }
 }

--- a/src/shell/test_builder.rs
+++ b/src/shell/test_builder.rs
@@ -6,6 +6,7 @@ use pretty_assertions::assert_eq;
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
+use std::rc::Rc;
 use tokio::task::JoinHandle;
 
 use crate::execute_with_pipes;
@@ -63,7 +64,7 @@ pub struct TestBuilder {
   // it is much much faster to lazily create this
   temp_dir: Option<TempDir>,
   env_vars: HashMap<String, String>,
-  custom_commands: HashMap<String, Box<dyn ShellCommand>>,
+  custom_commands: HashMap<String, Rc<dyn ShellCommand>>,
   command: String,
   stdin: Vec<u8>,
   expected_exit_code: i32,
@@ -142,7 +143,7 @@ impl TestBuilder {
   ) -> &mut Self {
     self
       .custom_commands
-      .insert(name.to_string(), Box::new(FnShellCommand(execute)));
+      .insert(name.to_string(), Rc::new(FnShellCommand(execute)));
     self
   }
 

--- a/src/shell/types.rs
+++ b/src/shell/types.rs
@@ -101,7 +101,7 @@ impl ShellState {
         }
       }
       EnvChange::Cd(new_dir) => {
-        self.cwd = new_dir.clone();
+        self.set_cwd(new_dir);
       }
     }
   }
@@ -131,8 +131,8 @@ impl ShellState {
     }
   }
 
-  pub fn token(&self) -> CancellationToken {
-    self.token.clone()
+  pub fn token(&self) -> &CancellationToken {
+    &self.token
   }
 
   pub fn resolve_command(&self, name: &str) -> Option<&dyn ShellCommand> {


### PR DESCRIPTION
This refactors out the code that resolves and executes a command in a separate process, makes it implement a `ShellCommand`, then exposes that.