### PR TITLE
fix: allow empty values for env vars by always inserting value

### DIFF
--- a/src/shell/test.rs
+++ b/src/shell/test.rs
@@ -66,6 +66,14 @@ pub async fn commands() {
     .await;
 
   TestBuilder::new()
+    .command(
+      r#"EMPTY= deno eval 'console.log(`EMPTY: ${Deno.env.get("EMPTY")}`)'"#,
+    )
+    .assert_stdout("EMPTY: \n")
+    .run()
+    .await;
+
+  TestBuilder::new()
     .command(r#""echo" "1""#)
     .assert_stdout("1\n")
     .run()

--- a/src/shell/types.rs
+++ b/src/shell/types.rs
@@ -124,11 +124,7 @@ impl ShellState {
       }
     } else {
       self.shell_vars.remove(&name);
-      if value.is_empty() {
-        self.env_vars.remove(&name);
-      } else {
-        self.env_vars.insert(name, value.to_string());
-      }
+      self.env_vars.insert(name, value.to_string());
     }
   }
 


### PR DESCRIPTION
This commit allows empty values for env vars in order to make the behavior consistent with the normal command execution.

Suppose we set an env var called FOO with `export FOO=` (note this is an empty), and we have a simple script that prints this env var:

```ts
console.log(`Foo: ${Deno.env.get("FOO")}`);
```

Running this script via `deno run` gets us `Foo: `.
While via `deno task` (with "foo": "deno run --allow-env foo.ts" in deno.json) it gets us `Foo: undefined`.
This might be a significant difference if it matters whether the env var is set or not. So this PR fixes this behavior by always setting given env vars even if they are empty.

I'm not really sure if there's a place where I can write a test case. Please let me know if there should be a test case.