### PR TITLE
feat: add `unset` command

### DIFF
--- a/src/shell/commands/mod.rs
+++ b/src/shell/commands/mod.rs
@@ -83,6 +83,10 @@ pub fn builtin_commands() -> HashMap<String, Rc<dyn ShellCommand>> {
       Rc::new(ExitCodeCommand(1)) as Rc<dyn ShellCommand>,
     ),
     (
+      "unset".to_string(),
+      Rc::new(unset::UnsetCommand) as Rc<dyn ShellCommand>,
+    ),
+    (
       "xargs".to_string(),
       Rc::new(xargs::XargsCommand) as Rc<dyn ShellCommand>,
     ),

--- a/src/shell/commands/mod.rs
+++ b/src/shell/commands/mod.rs
@@ -12,6 +12,7 @@ mod mkdir;
 mod pwd;
 mod rm;
 mod sleep;
+mod unset;
 mod xargs;
 
 use std::collections::HashMap;

--- a/src/shell/commands/unset.rs
+++ b/src/shell/commands/unset.rs
@@ -1,0 +1,88 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+use anyhow::bail;
+use anyhow::Result;
+use futures::future::LocalBoxFuture;
+
+use crate::shell::types::ExecuteResult;
+use crate::EnvChange;
+
+use super::ShellCommand;
+use super::ShellCommandContext;
+
+pub struct UnsetCommand;
+
+impl ShellCommand for UnsetCommand {
+  fn execute(
+    &self,
+    mut context: ShellCommandContext,
+  ) -> LocalBoxFuture<'static, ExecuteResult> {
+    let result = match parse_names(context.args) {
+      Ok(names) => ExecuteResult::Continue(
+        0,
+        names.into_iter().map(EnvChange::UnsetVar).collect(),
+        Vec::new(),
+      ),
+      Err(err) => {
+        context.stderr.write_line(&format!("unset: {err}")).unwrap();
+        ExecuteResult::Continue(1, Vec::new(), Vec::new())
+      }
+    };
+    Box::pin(futures::future::ready(result))
+  }
+}
+
+fn parse_names(mut args: Vec<String>) -> Result<Vec<String>> {
+  match args.get(0) {
+    None => {
+      // Running the actual `unset` with no argument completes with success.
+      Ok(args)
+    }
+    Some(flag) if flag == "-f" => bail!("unsupported flag: -f"),
+    Some(flag) if flag == "-v" => {
+      // It's fine to use `swap_remove` (instead of `remove`) because the order
+      // of args doesn't matter for `unset` command.
+      args.swap_remove(0);
+      Ok(args)
+    }
+    Some(_) => Ok(args),
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+
+  #[test]
+  fn parse_args() {
+    assert_eq!(
+      parse_names(vec!["VAR1".to_string()]).unwrap(),
+      vec!["VAR1".to_string()]
+    );
+    assert_eq!(
+      parse_names(vec!["VAR1".to_string(), "VAR2".to_string()]).unwrap(),
+      vec!["VAR1".to_string(), "VAR2".to_string()]
+    );
+    assert!(parse_names(vec![]).unwrap().is_empty());
+    assert_eq!(
+      parse_names(vec![
+        "-f".to_string(),
+        "VAR1".to_string(),
+        "VAR2".to_string()
+      ])
+      .err()
+      .unwrap()
+      .to_string(),
+      "unsupported flag: -f".to_string()
+    );
+    assert_eq!(
+      parse_names(vec![
+        "-v".to_string(),
+        "VAR1".to_string(),
+        "VAR2".to_string()
+      ])
+      .unwrap(),
+      vec!["VAR2".to_string(), "VAR1".to_string()]
+    );
+  }
+}

--- a/src/shell/test.rs
+++ b/src/shell/test.rs
@@ -116,6 +116,8 @@ pub async fn commands() {
     .assert_exit_code(1)
     .run()
     .await;
+
+  TestBuilder::new().command("unset").run().await;
 }
 
 #[tokio::test]

--- a/src/shell/test.rs
+++ b/src/shell/test.rs
@@ -772,6 +772,82 @@ pub async fn rm() {
     .await;
 }
 
+// Basic integration tests as there are unit tests in the commands
+#[tokio::test]
+pub async fn unset() {
+  // Unset 1 shell variable
+  TestBuilder::new()
+    .command(
+      r#"VAR1=1 && VAR2=2 && VAR3=3 && unset VAR1 && echo $VAR1 $VAR2 $VAR3"#,
+    )
+    .assert_stdout("2 3\n")
+    .run()
+    .await;
+
+  // Unset 1 env variable
+  TestBuilder::new()
+    .command(r#"export VAR1=1 VAR2=2 VAR3=3 && unset VAR1 && deno eval 'for (let i = 1; i <= 3; i++) { const val = Deno.env.get(`VAR${i}`); console.log(val); }'"#)
+    .assert_stdout("undefined\n2\n3\n")
+    .run()
+    .await;
+
+  // Unset 2 shell variables
+  TestBuilder::new()
+    .command(
+      r#"VAR1=1 && VAR2=2 && VAR3=3 && unset VAR1 VAR2 && echo $VAR1 $VAR2 $VAR3"#,
+    )
+    .assert_stdout("3\n")
+    .run()
+    .await;
+
+  // Unset 2 env variables
+  TestBuilder::new()
+    .command(r#"export VAR1=1 VAR2=2 VAR3=3 && unset VAR1 VAR2 && deno eval 'for (let i = 1; i <= 3; i++) { const val = Deno.env.get(`VAR${i}`); console.log(val); }'"#)
+    .assert_stdout("undefined\nundefined\n3\n")
+    .run()
+    .await;
+
+  // Unset 2 shell variables with -v enabled
+  TestBuilder::new()
+    .command(
+      r#"VAR1=1 && VAR2=2 && VAR3=3 && unset -v VAR1 VAR2 && echo $VAR1 $VAR2 $VAR3"#,
+    )
+    .assert_stdout("3\n")
+    .run()
+    .await;
+
+  // Unset 1 env variable with -v enabled
+  TestBuilder::new()
+    .command(r#"export VAR1=1 VAR2=2 VAR3=3 && unset -v VAR1 && deno eval 'for (let i = 1; i <= 3; i++) { const val = Deno.env.get(`VAR${i}`); console.log(val); }'"#)
+    .assert_stdout("undefined\n2\n3\n")
+    .run()
+    .await;
+
+  // Unset 2 env variables with -v enabled
+  TestBuilder::new()
+    .command(r#"export VAR1=1 VAR2=2 VAR3=3 && unset -v VAR1 VAR2 && deno eval 'for (let i = 1; i <= 3; i++) { const val = Deno.env.get(`VAR${i}`); console.log(val); }'"#)
+    .assert_stdout("undefined\nundefined\n3\n")
+    .run()
+    .await;
+
+  // Unset 1 shell variable and 1 env variable at the same time
+  TestBuilder::new()
+    .command(
+      r#"VAR=1 && export ENV_VAR=2 && unset VAR ENV_VAR && echo $VAR $ENV_VAR"#,
+    )
+    .assert_stdout("\n")
+    .run()
+    .await;
+
+  // -f is not supported
+  TestBuilder::new()
+    .command(r#"export VAR=42 && unset -f VAR"#)
+    .assert_stderr("unset: unsupported flag: -f\n")
+    .assert_exit_code(1)
+    .run()
+    .await;
+}
+
 #[tokio::test]
 pub async fn xargs() {
   TestBuilder::new()

--- a/src/shell/types.rs
+++ b/src/shell/types.rs
@@ -102,6 +102,7 @@ impl ShellState {
         }
       }
       EnvChange::UnsetVar(name) => {
+        self.shell_vars.remove(name);
         self.env_vars.remove(name);
       }
       EnvChange::Cd(new_dir) => {

--- a/src/shell/types.rs
+++ b/src/shell/types.rs
@@ -101,6 +101,9 @@ impl ShellState {
           self.shell_vars.insert(name.to_string(), value.to_string());
         }
       }
+      EnvChange::UnsetVar(name) => {
+        self.env_vars.remove(name);
+      }
       EnvChange::Cd(new_dir) => {
         self.set_cwd(new_dir);
       }
@@ -150,6 +153,8 @@ pub enum EnvChange {
   SetEnvVar(String, String),
   // `ENV_VAR=VALUE`
   SetShellVar(String, String),
+  // `unset ENV_VAR`
+  UnsetVar(String),
   Cd(PathBuf),
 }
 


### PR DESCRIPTION
This commit implements a new built-in command `unset` that simulates [POSIX's unset](https://man7.org/linux/man-pages/man1/unset.1p.html). It enables to completely unset shell variables or environment variables.