### PR TITLE
fix: remove some unwraps in commands outputting to stderr

### DIFF
--- a/src/shell/commands/cd.rs
+++ b/src/shell/commands/cd.rs
@@ -29,7 +29,7 @@ impl ShellCommand for CdCommand {
         ExecuteResult::Continue(0, vec![EnvChange::Cd(new_dir)], Vec::new())
       }
       Err(err) => {
-        context.stderr.write_line(&format!("cd: {err}")).unwrap();
+        _ = context.stderr.write_line(&format!("cd: {err}"));
         ExecuteResult::Continue(1, Vec::new(), Vec::new())
       }
     };

--- a/src/shell/commands/cp_mv.rs
+++ b/src/shell/commands/cp_mv.rs
@@ -44,7 +44,7 @@ async fn cp_command(
   match execute_cp(cwd, args).await {
     Ok(()) => ExecuteResult::from_exit_code(0),
     Err(err) => {
-      stderr.write_line(&format!("cp: {err}")).unwrap();
+      let _ = stderr.write_line(&format!("cp: {err}"));
       ExecuteResult::from_exit_code(1)
     }
   }
@@ -186,7 +186,7 @@ async fn mv_command(
   match execute_mv(cwd, args).await {
     Ok(()) => ExecuteResult::Continue(0, Vec::new(), Vec::new()),
     Err(err) => {
-      stderr.write_line(&format!("mv: {err}")).unwrap();
+      let _ = stderr.write_line(&format!("mv: {err}"));
       ExecuteResult::Continue(1, Vec::new(), Vec::new())
     }
   }

--- a/src/shell/commands/executable.rs
+++ b/src/shell/commands/executable.rs
@@ -35,7 +35,7 @@ impl ShellCommand for ExecutableCommand {
         }) {
           Ok(command_path) => command_path,
           Err(err) => {
-            stderr.write_line(&err.to_string()).unwrap();
+            let _ = stderr.write_line(&err.to_string());
             return ExecuteResult::Continue(1, Vec::new(), Vec::new());
           }
         };
@@ -72,7 +72,7 @@ impl ShellCommand for ExecutableCommand {
             Vec::new(),
           ),
           Err(err) => {
-            stderr.write_line(&format!("{err}")).unwrap();
+            let _ = stderr.write_line(&format!("{err}"));
             ExecuteResult::Continue(1, Vec::new(), Vec::new())
           }
         },

--- a/src/shell/commands/mkdir.rs
+++ b/src/shell/commands/mkdir.rs
@@ -40,7 +40,7 @@ async fn mkdir_command(
   match execute_mkdir(cwd, args).await {
     Ok(()) => ExecuteResult::Continue(0, Vec::new(), Vec::new()),
     Err(err) => {
-      stderr.write_line(&format!("mkdir: {err}")).unwrap();
+      let _ = stderr.write_line(&format!("mkdir: {err}"));
       ExecuteResult::Continue(1, Vec::new(), Vec::new())
     }
   }

--- a/src/shell/commands/rm.rs
+++ b/src/shell/commands/rm.rs
@@ -41,7 +41,7 @@ async fn rm_command(
   match execute_remove(cwd, args).await {
     Ok(()) => ExecuteResult::from_exit_code(0),
     Err(err) => {
-      stderr.write_line(&format!("rm: {err}")).unwrap();
+      let _ = stderr.write_line(&format!("rm: {err}"));
       ExecuteResult::from_exit_code(1)
     }
   }

--- a/src/shell/commands/sleep.rs
+++ b/src/shell/commands/sleep.rs
@@ -40,7 +40,7 @@ async fn sleep_command(
   match execute_sleep(args).await {
     Ok(()) => ExecuteResult::from_exit_code(0),
     Err(err) => {
-      stderr.write_line(&format!("sleep: {err}")).unwrap();
+      let _ = stderr.write_line(&format!("sleep: {err}"));
       ExecuteResult::from_exit_code(1)
     }
   }


### PR DESCRIPTION
It's better to not panic when stderr is closed in this cases.