### PR TITLE
feat: expose execute_with_pipes and the needed functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 pub mod parser;
 
 #[cfg(feature = "shell")]
-mod shell;
+pub mod shell;
 
 #[cfg(feature = "shell")]
 pub use shell::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 pub mod parser;
 
 #[cfg(feature = "shell")]
-pub mod shell;
+mod shell;
 
 #[cfg(feature = "shell")]
 pub use shell::*;

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -933,7 +933,8 @@ async fn execute_with_stdout_as_text(
 ///
 /// * A `ShellPipeWriter` for writing to the pipe.
 /// * A `JoinHandle<String>` that will return the output when awaited.
-pub fn writer_and_string_handle() -> (ShellPipeWriter, JoinHandle<String>) {
+pub fn pipe_writer_with_string_output() -> (ShellPipeWriter, JoinHandle<String>)
+{
   let (stdout_reader, stdout_writer) = pipe();
   let stdout_handle = tokio::task::spawn_blocking(|| {
     let mut buf = Vec::new();

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -14,6 +14,7 @@ pub use crate::shell::commands::ExecutableCommand;
 pub use crate::shell::commands::ExecuteCommandArgsContext;
 pub use crate::shell::commands::ShellCommand;
 pub use crate::shell::commands::ShellCommandContext;
+pub use crate::shell::types::pipe;
 pub use crate::shell::types::EnvChange;
 pub use crate::shell::types::ExecuteResult;
 pub use crate::shell::types::FutureExecuteResult;
@@ -923,12 +924,6 @@ async fn execute_with_stdout_as_text(
   String::from_utf8_lossy(&data).to_string()
 }
 
-/// Used to communicate between commands.
-pub fn pipe() -> (ShellPipeReader, ShellPipeWriter) {
-  let (reader, writer) = os_pipe::pipe().unwrap();
-  (ShellPipeReader(reader), ShellPipeWriter::OsPipe(writer))
-}
-
 /// Creates and returns a new `ShellPipeWriter` and its associated output handler.
 ///
 /// The output handler reads from the writer, stores the data in a buffer, and converts that buffer to a `String`.
@@ -938,7 +933,7 @@ pub fn pipe() -> (ShellPipeReader, ShellPipeWriter) {
 ///
 /// * A `ShellPipeWriter` for writing to the pipe.
 /// * A `JoinHandle<String>` that will return the output when awaited.
-pub fn get_output_writer_and_handle() -> (ShellPipeWriter, JoinHandle<String>) {
+pub fn writer_and_string_handle() -> (ShellPipeWriter, JoinHandle<String>) {
   let (stdout_reader, stdout_writer) = pipe();
   let stdout_handle = tokio::task::spawn_blocking(|| {
     let mut buf = Vec::new();

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -923,23 +923,3 @@ async fn execute_with_stdout_as_text(
   let data = output_handle.await.unwrap();
   String::from_utf8_lossy(&data).to_string()
 }
-
-/// Creates and returns a new `ShellPipeWriter` and its associated output handler.
-///
-/// The output handler reads from the writer, stores the data in a buffer, and converts that buffer to a `String`.
-/// This function is useful when reading the output of an execution, in for instance tests.
-///
-/// # Returns
-///
-/// * A `ShellPipeWriter` for writing to the pipe.
-/// * A `JoinHandle<String>` that will return the output when awaited.
-pub fn pipe_writer_with_string_output() -> (ShellPipeWriter, JoinHandle<String>)
-{
-  let (stdout_reader, stdout_writer) = pipe();
-  let stdout_handle = tokio::task::spawn_blocking(|| {
-    let mut buf = Vec::new();
-    stdout_reader.pipe_to(&mut buf).unwrap();
-    String::from_utf8_lossy(&buf).to_string()
-  });
-  (stdout_writer, stdout_handle)
-}

--- a/src/shell/test_builder.rs
+++ b/src/shell/test_builder.rs
@@ -7,16 +7,13 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 use std::rc::Rc;
-use tokio::task::JoinHandle;
 
-use crate::execute_with_pipes;
 use crate::parser::parse;
 use crate::shell::fs_util;
-use crate::shell::types::pipe;
-use crate::shell::types::ShellPipeWriter;
 use crate::shell::types::ShellState;
 use crate::ShellCommand;
 use crate::ShellCommandContext;
+use crate::{execute_with_pipes, get_output_writer_and_handle, pipe};
 
 use super::types::ExecuteResult;
 
@@ -276,14 +273,4 @@ impl TestBuilder {
       }
     }
   }
-}
-
-fn get_output_writer_and_handle() -> (ShellPipeWriter, JoinHandle<String>) {
-  let (stdout_reader, stdout_writer) = pipe();
-  let stdout_handle = tokio::task::spawn_blocking(|| {
-    let mut buf = Vec::new();
-    stdout_reader.pipe_to(&mut buf).unwrap();
-    String::from_utf8_lossy(&buf).to_string()
-  });
-  (stdout_writer, stdout_handle)
 }

--- a/src/shell/test_builder.rs
+++ b/src/shell/test_builder.rs
@@ -11,9 +11,9 @@ use std::rc::Rc;
 use crate::execute_with_pipes;
 use crate::parser::parse;
 use crate::pipe;
+use crate::pipe_writer_with_string_output;
 use crate::shell::fs_util;
 use crate::shell::types::ShellState;
-use crate::writer_and_string_handle;
 use crate::ShellCommand;
 use crate::ShellCommandContext;
 
@@ -209,8 +209,8 @@ impl TestBuilder {
     let (stdin, mut stdin_writer) = pipe();
     stdin_writer.write_all(&self.stdin).unwrap();
     drop(stdin_writer); // prevent a deadlock by dropping the writer
-    let (stdout, stdout_handle) = writer_and_string_handle();
-    let (stderr, stderr_handle) = writer_and_string_handle();
+    let (stdout, stdout_handle) = pipe_writer_with_string_output();
+    let (stderr, stderr_handle) = pipe_writer_with_string_output();
 
     let local_set = tokio::task::LocalSet::new();
     let state = ShellState::new(

--- a/src/shell/test_builder.rs
+++ b/src/shell/test_builder.rs
@@ -11,13 +11,12 @@ use tokio::task::JoinHandle;
 
 use crate::execute_with_pipes;
 use crate::parser::parse;
-use crate::pipe;
-use crate::pipe_reader_to_string_handle;
 use crate::shell::fs_util;
+use crate::shell::types::pipe;
+use crate::shell::types::ShellPipeWriter;
 use crate::shell::types::ShellState;
 use crate::ShellCommand;
 use crate::ShellCommandContext;
-use crate::ShellPipeWriter;
 
 use super::types::ExecuteResult;
 

--- a/src/shell/test_builder.rs
+++ b/src/shell/test_builder.rs
@@ -8,12 +8,14 @@ use std::fs;
 use std::path::PathBuf;
 use std::rc::Rc;
 
+use crate::execute_with_pipes;
 use crate::parser::parse;
+use crate::pipe;
 use crate::shell::fs_util;
 use crate::shell::types::ShellState;
+use crate::writer_and_string_handle;
 use crate::ShellCommand;
 use crate::ShellCommandContext;
-use crate::{execute_with_pipes, get_output_writer_and_handle, pipe};
 
 use super::types::ExecuteResult;
 
@@ -207,8 +209,8 @@ impl TestBuilder {
     let (stdin, mut stdin_writer) = pipe();
     stdin_writer.write_all(&self.stdin).unwrap();
     drop(stdin_writer); // prevent a deadlock by dropping the writer
-    let (stdout, stdout_handle) = get_output_writer_and_handle();
-    let (stderr, stderr_handle) = get_output_writer_and_handle();
+    let (stdout, stdout_handle) = writer_and_string_handle();
+    let (stderr, stderr_handle) = writer_and_string_handle();
 
     let local_set = tokio::task::LocalSet::new();
     let state = ShellState::new(

--- a/src/shell/types.rs
+++ b/src/shell/types.rs
@@ -193,7 +193,7 @@ impl ExecuteResult {
 }
 
 /// Reader side of a pipe.
-pub struct ShellPipeReader(os_pipe::PipeReader);
+pub struct ShellPipeReader(pub os_pipe::PipeReader);
 
 impl Clone for ShellPipeReader {
   fn clone(&self) -> Self {
@@ -345,10 +345,4 @@ impl ShellPipeWriter {
     let bytes = format!("{line}\n");
     self.write_all(bytes.as_bytes())
   }
-}
-
-/// Used to communicate between commands.
-pub fn pipe() -> (ShellPipeReader, ShellPipeWriter) {
-  let (reader, writer) = os_pipe::pipe().unwrap();
-  (ShellPipeReader(reader), ShellPipeWriter::OsPipe(writer))
 }

--- a/src/shell/types.rs
+++ b/src/shell/types.rs
@@ -262,6 +262,16 @@ impl ShellPipeReader {
       ShellPipeWriter::Null => Ok(()),
     }
   }
+
+  /// Pipes the reader to a string handle that is resolved when the pipe's
+  /// writer is closed.
+  pub fn pipe_to_string_handle(self) -> JoinHandle<String> {
+    tokio::task::spawn_blocking(|| {
+      let mut buf = Vec::new();
+      self.pipe_to(&mut buf).unwrap();
+      String::from_utf8_lossy(&buf).to_string()
+    })
+  }
 }
 
 /// Writer side of a pipe.

--- a/src/shell/types.rs
+++ b/src/shell/types.rs
@@ -193,7 +193,7 @@ impl ExecuteResult {
 }
 
 /// Reader side of a pipe.
-pub struct ShellPipeReader(pub os_pipe::PipeReader);
+pub struct ShellPipeReader(os_pipe::PipeReader);
 
 impl Clone for ShellPipeReader {
   fn clone(&self) -> Self {

--- a/src/shell/types.rs
+++ b/src/shell/types.rs
@@ -346,3 +346,9 @@ impl ShellPipeWriter {
     self.write_all(bytes.as_bytes())
   }
 }
+
+/// Used to communicate between commands.
+pub fn pipe() -> (ShellPipeReader, ShellPipeWriter) {
+  let (reader, writer) = os_pipe::pipe().unwrap();
+  (ShellPipeReader(reader), ShellPipeWriter::OsPipe(writer))
+}


### PR DESCRIPTION
As requested in #86 we want to use the `deno_task_shell` in the same way as `deno` does.
We would like to run tests as the `test_builder` is doing for this project.

This PR makes `execute_with_pipes` a public function and the necessary functions to run the tests with that as well. 
I also tried to add some documentation, please check if I interpreted the code correctly. 

To see what we did with it check out this PR: https://github.com/prefix-dev/pixi/pull/173

Thanks for making this a library! 

Closes #86 