### PR TITLE
fix: ensure single quoted strings are maintained mid-word

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -758,7 +758,10 @@ fn parse_word_parts(
       |input| match mode {
         ParseWordPartsMode::DoubleQuotes => ParseError::backtrace(),
         ParseWordPartsMode::Unquoted => {
-          let (input, parts) = parse_quoted_string(input)?;
+          let (input, parts) =
+            map(parse_quoted_string, |parts| vec![WordPart::Quoted(parts)])(
+              input,
+            )?;
           Ok((input, PendingPart::Parts(parts)))
         }
       },
@@ -1313,6 +1316,18 @@ mod test {
       parse_quoted_string,
       "'  ",
       Err("Expected closing single quote."),
+    );
+  }
+
+  #[test]
+  fn test_single_quotes_mid_word() {
+    run_test(
+      parse_word,
+      "--inspect='[::0]:3366'",
+      Ok(Word(vec![
+        WordPart::Text("--inspect=".to_string()),
+        WordPart::Quoted(vec![WordPart::Text("[::0]:3366".to_string())]),
+      ])),
     );
   }
 

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -674,6 +674,7 @@ fn evaluate_word_parts(
   stdin: ShellPipeReader,
   stderr: ShellPipeWriter,
 ) -> LocalBoxFuture<Result<Vec<String>, EvaluateWordTextError>> {
+  #[derive(Debug)]
   enum TextPart {
     Quoted(String),
     Text(String),

--- a/src/shell/test.rs
+++ b/src/shell/test.rs
@@ -1102,6 +1102,14 @@ async fn glob_basic() {
     .assert_exit_code(0)
     .run()
     .await;
+
+  TestBuilder::new()
+    .command("echo --inspect='[::0]:3366'")
+    .assert_stderr("")
+    .assert_stdout("--inspect=[::0]:3366\n")
+    .assert_exit_code(0)
+    .run()
+    .await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
For https://github.com/denoland/deno/issues/19942