### PR TITLE
feat: support file input redirects

### DIFF
--- a/src/shell/test.rs
+++ b/src/shell/test.rs
@@ -463,7 +463,7 @@ async fn negated() {
 }
 
 #[tokio::test]
-async fn redirects() {
+async fn redirects_output() {
   TestBuilder::new()
     .command(r#"echo 5 6 7 > test.txt"#)
     .assert_file_equals("test.txt", "5 6 7\n")
@@ -560,6 +560,23 @@ async fn redirects() {
     .command(r#"echo 1 > $EMPTY"#)
     .assert_stderr("redirect path must be 1 argument, but found 0\n")
     .assert_exit_code(1)
+    .run()
+    .await;
+}
+
+#[tokio::test]
+async fn redirects_input() {
+  TestBuilder::new()
+    .file("test.txt", "Hi!")
+    .command(r#"cat - < test.txt"#)
+    .assert_stdout("Hi!")
+    .run()
+    .await;
+
+  TestBuilder::new()
+    .file("test.txt", "Hi!\n")
+    .command(r#"cat - < test.txt && echo There"#)
+    .assert_stdout("Hi!\nThere\n")
     .run()
     .await;
 }


### PR DESCRIPTION
Supports input redirects where the specified file on the right hand side is redirected to the stdin of the pipeline on the left:

```
gzip < file.txt
```

(I want this for Dax because I'm investigating doing something similar to Bun's shell in Dax where you can provide objects to the shell. I got it working, but not sure how I feel about it though because other APIs seem better and more clear)
