### PR TITLE
feat: support parsing fd redirects

### DIFF
--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -10,6 +10,7 @@ use futures::FutureExt;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
+use crate::parser::IoFile;
 use crate::parser::RedirectOpInput;
 use crate::parser::RedirectOpOutput;
 pub use crate::shell::commands::ExecutableCommand;
@@ -375,8 +376,17 @@ async fn resolve_redirect_pipe(
     }
   }
 
+  let word = match redirect.io_file.clone() {
+    IoFile::Word(word) => word,
+    IoFile::Fd(_) => {
+      let _ = stderr.write_line(
+        "deno_task_shell: redirecting file descriptors is not implemented",
+      );
+      return Err(ExecuteResult::from_exit_code(1));
+    }
+  };
   let words = evaluate_word_parts(
-    redirect.io_file.clone().into_parts(),
+    word.into_parts(),
     state,
     stdin.clone(),
     stderr.clone(),

--- a/src/shell/test.rs
+++ b/src/shell/test.rs
@@ -600,23 +600,6 @@ async fn redirects_input() {
 }
 
 #[tokio::test]
-async fn redirects_input() {
-  TestBuilder::new()
-    .file("test.txt", "Hi!")
-    .command(r#"cat - < test.txt"#)
-    .assert_stdout("Hi!")
-    .run()
-    .await;
-
-  TestBuilder::new()
-    .file("test.txt", "Hi!\n")
-    .command(r#"cat - < test.txt && echo There"#)
-    .assert_stdout("Hi!\nThere\n")
-    .run()
-    .await;
-}
-
-#[tokio::test]
 async fn pwd() {
   TestBuilder::new()
     .directory("sub_dir")

--- a/src/shell/test.rs
+++ b/src/shell/test.rs
@@ -463,7 +463,7 @@ async fn negated() {
 }
 
 #[tokio::test]
-async fn redirects() {
+async fn redirects_output() {
   TestBuilder::new()
     .command(r#"echo 5 6 7 > test.txt"#)
     .assert_file_equals("test.txt", "5 6 7\n")
@@ -560,6 +560,23 @@ async fn redirects() {
     .command(r#"echo 1 > $EMPTY"#)
     .assert_stderr("redirect path must be 1 argument, but found 0\n")
     .assert_exit_code(1)
+    .run()
+    .await;
+}
+
+#[tokio::test]
+async fn redirects_input() {
+  TestBuilder::new()
+    .file("test.txt", "Hi!")
+    .command(r#"cat - < test.txt"#)
+    .assert_stdout("Hi!")
+    .run()
+    .await;
+
+  TestBuilder::new()
+    .file("test.txt", "Hi!\n")
+    .command(r#"cat - < test.txt && echo There"#)
+    .assert_stdout("Hi!\nThere\n")
     .run()
     .await;
 }

--- a/src/shell/test.rs
+++ b/src/shell/test.rs
@@ -562,6 +562,15 @@ async fn redirects_output() {
     .assert_exit_code(1)
     .run()
     .await;
+
+  TestBuilder::new()
+    .command(r#"echo 1 >&2"#)
+    .assert_stderr(
+      "deno_task_shell: redirecting file descriptors is not implemented\n",
+    )
+    .assert_exit_code(1)
+    .run()
+    .await;
 }
 
 #[tokio::test]
@@ -577,6 +586,15 @@ async fn redirects_input() {
     .file("test.txt", "Hi!\n")
     .command(r#"cat - < test.txt && echo There"#)
     .assert_stdout("Hi!\nThere\n")
+    .run()
+    .await;
+
+  TestBuilder::new()
+    .command(r#"cat - <&0"#)
+    .assert_stderr(
+      "deno_task_shell: redirecting file descriptors is not implemented\n",
+    )
+    .assert_exit_code(1)
     .run()
     .await;
 }


### PR DESCRIPTION
~~Waiting on https://github.com/denoland/deno_task_shell/pull/106~~

This implements fd redirects in the parser (because I want it for Dax). We can do the shell implementation later.