### PR TITLE
feat: `ShellCommandContext` - ability to resolve path to command

### DIFF
--- a/src/shell/commands/mod.rs
+++ b/src/shell/commands/mod.rs
@@ -17,6 +17,7 @@ mod unset;
 mod xargs;
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::rc::Rc;
 
 use futures::future::LocalBoxFuture;
@@ -114,6 +115,22 @@ pub struct ShellCommandContext {
   pub stderr: ShellPipeWriter,
   pub execute_command_args:
     Box<dyn FnOnce(ExecuteCommandArgsContext) -> FutureExecuteResult>,
+}
+
+impl ShellCommandContext {
+  /// Resolves the path to a command from the current working directory.
+  ///
+  /// Does not take injected custom commands into account.
+  pub fn resolve_command_path(
+    &self,
+    command_name: &str,
+  ) -> Result<PathBuf, crate::ResolveCommandPathError> {
+    super::command::resolve_command_path(
+      command_name,
+      self.state.cwd(),
+      &self.state,
+    )
+  }
 }
 
 pub trait ShellCommand {

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2024 the Deno authors. MIT license.
 
+pub use command::ResolveCommandPathError;
 pub use commands::ExecutableCommand;
 pub use commands::ExecuteCommandArgsContext;
 pub use commands::ShellCommand;

--- a/src/shell/test.rs
+++ b/src/shell/test.rs
@@ -1157,6 +1157,26 @@ async fn custom_command() {
 }
 
 #[tokio::test]
+async fn custom_command_resolve_command_path() {
+  TestBuilder::new()
+    .command("$(custom_which deno) eval 'console.log(1)'")
+    .custom_command(
+      "custom_which",
+      Box::new(|mut context| {
+        async move {
+          let path = context.resolve_command_path(&context.args[0]).unwrap();
+          let _ = context.stdout.write_line(&path.to_string_lossy());
+          ExecuteResult::from_exit_code(0)
+        }
+        .boxed_local()
+      }),
+    )
+    .assert_stdout("1\n")
+    .run()
+    .await;
+}
+
+#[tokio::test]
 async fn glob_basic() {
   TestBuilder::new()
     .file("test.txt", "test\n")


### PR DESCRIPTION
Will be for getting the path to the `npx` executable.