### PR TITLE
fix(BREAKING): move `.resolve_command_path` to `ShellState`

### DIFF
--- a/src/shell/commands/mod.rs
+++ b/src/shell/commands/mod.rs
@@ -17,7 +17,6 @@ mod unset;
 mod xargs;
 
 use std::collections::HashMap;
-use std::path::PathBuf;
 use std::rc::Rc;
 
 use futures::future::LocalBoxFuture;
@@ -115,22 +114,6 @@ pub struct ShellCommandContext {
   pub stderr: ShellPipeWriter,
   pub execute_command_args:
     Box<dyn FnOnce(ExecuteCommandArgsContext) -> FutureExecuteResult>,
-}
-
-impl ShellCommandContext {
-  /// Resolves the path to a command from the current working directory.
-  ///
-  /// Does not take injected custom commands into account.
-  pub fn resolve_command_path(
-    &self,
-    command_name: &str,
-  ) -> Result<PathBuf, crate::ResolveCommandPathError> {
-    super::command::resolve_command_path(
-      command_name,
-      self.state.cwd(),
-      &self.state,
-    )
-  }
 }
 
 pub trait ShellCommand {

--- a/src/shell/execute.rs
+++ b/src/shell/execute.rs
@@ -670,7 +670,7 @@ fn execute_command_args(
         )
       }),
     };
-    match command_context.state.resolve_command(&command_name) {
+    match command_context.state.resolve_custom_command(&command_name) {
       Some(command) => command.execute(command_context),
       None => execute_unresolved_command_name(
         UnresolvedCommandName {

--- a/src/shell/test.rs
+++ b/src/shell/test.rs
@@ -1164,7 +1164,10 @@ async fn custom_command_resolve_command_path() {
       "custom_which",
       Box::new(|mut context| {
         async move {
-          let path = context.resolve_command_path(&context.args[0]).unwrap();
+          let path = context
+            .state
+            .resolve_command_path(&context.args[0])
+            .unwrap();
           let _ = context.stdout.write_line(&path.to_string_lossy());
           ExecuteResult::from_exit_code(0)
         }

--- a/src/shell/types.rs
+++ b/src/shell/types.rs
@@ -135,9 +135,23 @@ impl ShellState {
     &self.token
   }
 
-  pub fn resolve_command(&self, name: &str) -> Option<Rc<dyn ShellCommand>> {
+  /// Resolves a custom command that was injected.
+  pub fn resolve_custom_command(
+    &self,
+    name: &str,
+  ) -> Option<Rc<dyn ShellCommand>> {
     // uses an Rc to allow resolving a command without borrowing from self
     self.commands.get(name).cloned()
+  }
+
+  /// Resolves the path to a command from the current working directory.
+  ///
+  /// Does not take injected custom commands into account.
+  pub fn resolve_command_path(
+    &self,
+    command_name: &str,
+  ) -> Result<PathBuf, crate::ResolveCommandPathError> {
+    super::command::resolve_command_path(command_name, self.cwd(), self)
   }
 
   pub fn with_child_token(&self) -> ShellState {


### PR DESCRIPTION
For the future. I just realized this when debugging something in the CLI.

This moves the method to where the other functionality is and this is more versatile.