### PR TITLE
fix: use current deno executable even when not named deno

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,11 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: denoland/setup-deno@v1
+        with:
+          deno-version: canary
       - uses: dsherret/rust-toolchain-file@v1
 
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,13 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.DENOBOT_PAT }}
 
       - uses: denoland/setup-deno@v1
+        with:
+          deno-version: canary
       - uses: dsherret/rust-toolchain-file@v1
 
       - name: Tag and release
@@ -34,4 +36,4 @@ jobs:
         run: |
           git config user.email "denobot@users.noreply.github.com"
           git config user.name "denobot"
-          deno run -A https://raw.githubusercontent.com/denoland/automation/0.14.1/tasks/publish_release.ts --${{github.event.inputs.releaseKind}}
+          deno run -A https://raw.githubusercontent.com/denoland/automation/0.20.0/tasks/publish_release.ts --${{github.event.inputs.releaseKind}}

--- a/src/shell/test.rs
+++ b/src/shell/test.rs
@@ -1444,7 +1444,7 @@ async fn cross_platform_shebang() {
   // without -S, but valid
   TestBuilder::new()
     .file("file.ts", "#!/usr/bin/env ./echo_stdin.ts\nconsole.log('Hello')")
-    .file("echo_stdin.ts", "#!/usr/bin/env -S deno run --allow-run\nawait new Deno.Command('deno', { args: ['run', ...Deno.args] }).spawn();")
+    .file("echo_stdin.ts", "#!/usr/bin/env -S deno run --allow-all\nawait new Deno.Command('deno', { args: ['run', ...Deno.args] }).spawn();")
     .command("./file.ts")
     .assert_stdout("Hello\n")
     .run()
@@ -1454,7 +1454,7 @@ async fn cross_platform_shebang() {
   TestBuilder::new()
     .directory("sub")
     .file("sub/file.ts", "#!/usr/bin/env ../echo_stdin.ts\nconsole.log('Hello')")
-    .file("echo_stdin.ts", "#!/usr/bin/env -S deno run --allow-run\nawait new Deno.Command('deno', { args: ['run', ...Deno.args] }).spawn();")
+    .file("echo_stdin.ts", "#!/usr/bin/env -S deno run --allow-all\nawait new Deno.Command('deno', { args: ['run', ...Deno.args] }).spawn();")
     .command("./sub/file.ts")
     .assert_stdout("Hello\n")
     .run()

--- a/src/shell/which.rs
+++ b/src/shell/which.rs
@@ -46,7 +46,7 @@ pub fn resolve_command_path<'a>(
       // this condition exists to make the tests pass because it's not
       // using the deno as the current executable
       let file_stem = exe_path.file_stem().map(|s| s.to_string_lossy());
-      if file_stem.map(|s| s.to_string()) == Some("deno".to_string()) {
+      if file_stem.map(|s| !s.starts_with("deno_task_shell-")).unwrap_or(true) {
         return Ok(exe_path);
       }
     }

--- a/src/shell/which.rs
+++ b/src/shell/which.rs
@@ -46,7 +46,10 @@ pub fn resolve_command_path<'a>(
       // this condition exists to make the tests pass because it's not
       // using the deno as the current executable
       let file_stem = exe_path.file_stem().map(|s| s.to_string_lossy());
-      if file_stem.map(|s| !s.starts_with("deno_task_shell-")).unwrap_or(true) {
+      if file_stem
+        .map(|s| !s.starts_with("deno_task_shell-"))
+        .unwrap_or(true)
+      {
         return Ok(exe_path);
       }
     }

--- a/src/shell/which.rs
+++ b/src/shell/which.rs
@@ -145,6 +145,15 @@ mod local_test {
     )
     .unwrap();
     assert_eq!(path, PathBuf::from("/bin/deno.exe"));
+
+    let path = resolve_command_path(
+      "deno",
+      &cwd,
+      |_| None,
+      || Ok(PathBuf::from("/bin/deno_other")),
+    )
+    .unwrap();
+    assert_eq!(path, PathBuf::from("/bin/deno_other"));
   }
 
   #[test]


### PR DESCRIPTION
For https://github.com/denoland/deno/issues/26005