### PR TITLE
feat: Kill child processes when task shell receives ctrl-c

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ anyhow = "1.0.75"
 futures = { version = "0.3.29", optional = true }
 glob = { version = "0.3.1", optional = true }
 path-dedot = { version = "3.1.1", optional = true }
-tokio = { version = "1", features = ["fs", "io-std", "io-util", "macros", "process", "rt-multi-thread", "sync", "time"], optional = true }
+tokio = { version = "1", features = ["fs", "io-std", "io-util", "macros", "process", "rt-multi-thread", "sync", "time", "signal"], optional = true }
 tokio-util = { version = "0.7.10", optional = true }
 os_pipe = { version = "1.1.4", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }


### PR DESCRIPTION
When running docker compose from "deno task" you get bad CTRL-C handling compared to "npm run". This problem can be reproduced by running "npm run docker-compose" and "deno task docker-compose" in this minimal testcase repo:
https://github.com/mo/deno-tasks-signal-issue-repro

There is some more info in this issue:
https://github.com/denoland/deno_task_shell/issues/33

```

The main purpose of the PR is to make sure all of these behave well with ctrl-c:
{
  "tasks": {
    "docker-compose": "./docker-compose.sh",
    "docker-compose-no-sh-file": "docker compose -f compose.yaml up",
    "sleep": "sleep 999",
    "simple-builtin": "echo hello",
    "simple-bin": "date",
    "cmd": "cat /dev/urandom | head -c 1000000 | sha256sum",
    "hashpipe-slow": "$(which cat) /dev/urandom | $(which head) -c 1000000000 | sha256sum",
    "hashpipe-slower": "$(which cat) /dev/urandom | $(which head) -c 10000000000 | sha256sum",
    "forever-pipe": "yes | grep -v mystery | grep -v magic | sort | uniq -c",
  }
}
```

When this PR is applied, "deno task docker-compose" works similar to "npm run", however the code is the PR needs some cleanup.

I tried to clean it up by not spawning a tokio task however that version doesn't solve the main docker compose use case and unfortunately I don't understand why that is. This version also prints some debug info with a new empty lines just to make sure the debug print outs doesn't get overwritten by the docker compose "progress" printouts:
https://github.com/mo/deno_task_shell/commit/7514eba7d5860a51a9112c6f93416d8edaea4bf4

@dsherret already provided some feedback on needed cleanup of this PR in an earlier PR which was incorrectly pushed with the PR-commit directly on "main".. so the current PR just aims to re-create the PR so that maintainer edits are possible. The old PR was:
https://github.com/denoland/deno_task_shell/pull/125
