### PR TITLE
refactor: force supply a cancellation token

### DIFF
--- a/src/shell/execute.rs
+++ b/src/shell/execute.rs
@@ -54,6 +54,7 @@ use super::types::CANCELLATION_EXIT_CODE;
 /// * `env_vars` - A map of environment variables which are set in the shell.
 /// * `cwd` - The current working directory.
 /// * `custom_commands` - A map of custom shell commands and there ShellCommand implementation.
+/// * `token` - Use to cancel the shell and all spawned executables.
 ///
 /// # Returns
 /// The exit code of the command execution.
@@ -62,8 +63,9 @@ pub async fn execute(
   env_vars: HashMap<String, String>,
   cwd: &Path,
   custom_commands: HashMap<String, Rc<dyn ShellCommand>>,
+  token: CancellationToken,
 ) -> i32 {
-  let state = ShellState::new(env_vars, cwd, custom_commands);
+  let state = ShellState::new(env_vars, cwd, custom_commands, token);
   execute_with_pipes(
     list,
     state,

--- a/src/shell/test.rs
+++ b/src/shell/test.rs
@@ -1,6 +1,9 @@
 // Copyright 2018-2024 the Deno authors. MIT license.
 
+use std::time::Instant;
+
 use futures::FutureExt;
+use tokio_util::sync::CancellationToken;
 
 use super::test_builder::TestBuilder;
 use super::types::ExecuteResult;
@@ -1472,6 +1475,20 @@ async fn cross_platform_shebang() {
 "#)
     .run()
     .await;
+}
+
+#[tokio::test]
+async fn provided_token_cancel() {
+  let token = CancellationToken::new();
+  token.cancel();
+  let start_time = Instant::now();
+  TestBuilder::new()
+    .command("sleep 5")
+    .token(token)
+    .assert_exit_code(130)
+    .run()
+    .await;
+  assert!(start_time.elapsed().as_secs() < 1);
 }
 
 fn no_such_file_error_text() -> &'static str {

--- a/src/shell/types.rs
+++ b/src/shell/types.rs
@@ -37,6 +37,7 @@ impl ShellState {
     env_vars: HashMap<String, String>,
     cwd: &Path,
     custom_commands: HashMap<String, Rc<dyn ShellCommand>>,
+    token: CancellationToken,
   ) -> Self {
     assert!(cwd.is_absolute());
     let mut commands = builtin_commands();
@@ -46,7 +47,7 @@ impl ShellState {
       shell_vars: Default::default(),
       cwd: PathBuf::new(),
       commands: Rc::new(commands),
-      token: CancellationToken::default(),
+      token,
     };
     // ensure the data is normalized
     for (name, value) in env_vars {


### PR DESCRIPTION
People should be providing this in order to cancel spawned executables.