### PR TITLE
feat: make deno executable name configurable

### DIFF
--- a/src/shell/which.rs
+++ b/src/shell/which.rs
@@ -6,6 +6,11 @@ use std::path::PathBuf;
 
 use thiserror::Error;
 
+pub const EXECUTABLE_NAME: &str = match option_env!("DENO_EXECUTABLE_NAME") {
+  Some(name) => name,
+  None => "deno",
+};
+
 /// Error when a command path could not be resolved.
 #[derive(Error, Debug, PartialEq)]
 pub enum CommandPathResolutionError {
@@ -41,7 +46,7 @@ pub fn resolve_command_path<'a>(
   // that don't have deno on the path and to ensure it use the current
   // version of deno being executed rather than the one on the path,
   // which has caused some confusion.
-  if command_name == "deno" {
+  if command_name == EXECUTABLE_NAME {
     if let Ok(exe_path) = current_exe() {
       // this condition exists to make the tests pass because it's not
       // using the deno as the current executable


### PR DESCRIPTION
At [pixi](https://github.com/prefix-dev/pixi) we use the `deno_task_shell` in a very similar way as deno does. Like deno, `pixi` can manage packages, including deno. However, with the current setup `pixi run deno` leads to pixi being called rather than deno. Therefore, we'd appreciate if we could configure the executable name. This allows us to configure it like this in `config.toml`:
```toml
[env]
# Needed so that `pixi run deno`, calls deno instead of pixi
DENO_EXECUTABLE_NAME = "pixi"
```

Related issue: https://github.com/prefix-dev/pixi/issues/2982