### PR TITLE
refactor: extract out integration tests

### DIFF
--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -24,8 +24,3 @@ mod execute;
 mod fs_util;
 mod types;
 pub mod which;
-
-#[cfg(test)]
-mod test;
-#[cfg(test)]
-mod test_builder;

--- a/src/shell/which.rs
+++ b/src/shell/which.rs
@@ -65,7 +65,7 @@ pub fn resolve_command_path<'a>(
       // using the deno as the current executable
       let file_stem = exe_path.file_stem().map(|s| s.to_string_lossy());
       if file_stem
-        .map(|s| !s.starts_with("deno_task_shell-"))
+        .map(|s| !s.starts_with("integration_test-"))
         .unwrap_or(true)
       {
         return Ok(exe_path);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4,12 +4,13 @@ use std::time::Duration;
 use std::time::Instant;
 
 use futures::FutureExt;
+use deno_task_shell::KillSignal;
+use deno_task_shell::SignalKind;
+use deno_task_shell::ExecuteResult;
 
-use crate::KillSignal;
-use crate::SignalKind;
+use self::test_builder::TestBuilder;
 
-use super::test_builder::TestBuilder;
-use super::types::ExecuteResult;
+mod test_builder;
 
 const FOLDER_SEPERATOR: char = if cfg!(windows) { '\\' } else { '/' };
 


### PR DESCRIPTION
Every time I would open this project it would take me a minute to find the tests because I'd forget where they were. This should be more clear.