### PR TITLE
fix: move sys_traits to shell feature to fix Wasm build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,9 @@ jobs:
 
       - name: Build only parser in Wasm
         if: contains(matrix.os, 'ubuntu')
-        run: cargo build --no-default-features --target wasm32-unknown-unknown
+        run: |
+          rutup target add wasm32-unknown-unknown
+          cargo build --no-default-features --target wasm32-unknown-unknown
       - name: Build
         run: cargo build --all-targets --all-features --release
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,9 @@ jobs:
         if: contains(matrix.os, 'ubuntu')
         run: cargo clippy --all-targets --all-features --release
 
-      - name: Build only parser
+      - name: Build only parser in Wasm
         if: contains(matrix.os, 'ubuntu')
-        run: cargo build --no-default-features
+        run: cargo build --no-default-features --target wasm32-unknown-unknown
       - name: Build
         run: cargo build --all-targets --all-features --release
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Build only parser in Wasm
         if: contains(matrix.os, 'ubuntu')
         run: |
-          rutup target add wasm32-unknown-unknown
+          rustup target add wasm32-unknown-unknown
           cargo build --no-default-features --target wasm32-unknown-unknown
       - name: Build
         run: cargo build --all-targets --all-features --release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ description = "Cross platform scripting for deno task"
 
 [features]
 default = ["shell"]
-shell = ["futures", "glob", "nix", "os_pipe", "path-dedot", "tokio", "windows-sys", "sys_traits/real", "sys_traits/winapi", "sys_traits/libc"]
+shell = ["futures", "glob", "nix", "os_pipe", "path-dedot", "tokio", "windows-sys", "sys_traits"]
 serialization = ["serde"]
 
 [dependencies]
@@ -25,7 +25,7 @@ monch = "0.5.0"
 thiserror = "2.0.9"
 tokio = { version = "1", features = ["fs", "io-std", "io-util", "macros", "process", "rt-multi-thread", "sync", "time"], optional = true }
 deno_path_util = "0.3.2"
-sys_traits = "0.1.9"
+sys_traits = { version = "0.1.9", optional = true, features = ["real", "winapi", "libc"] }
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.29.0", features = ["signal"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ description = "Cross platform scripting for deno task"
 
 [features]
 default = ["shell"]
-shell = ["futures", "glob", "nix", "os_pipe", "path-dedot", "tokio", "windows-sys"]
+shell = ["futures", "glob", "nix", "os_pipe", "path-dedot", "tokio", "windows-sys", "sys_traits/real", "sys_traits/winapi", "sys_traits/libc"]
 serialization = ["serde"]
 
 [dependencies]
@@ -25,7 +25,7 @@ monch = "0.5.0"
 thiserror = "2.0.9"
 tokio = { version = "1", features = ["fs", "io-std", "io-util", "macros", "process", "rt-multi-thread", "sync", "time"], optional = true }
 deno_path_util = "0.3.2"
-sys_traits = { version = "0.1.9", features = ["real", "winapi", "libc"] }
+sys_traits = "0.1.9"
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.29.0", features = ["signal"], optional = true }


### PR DESCRIPTION
This isn't necessary when only using deno_task_shell for serialization in Wasm.