### PR TITLE
feat(BREAKING): support multi-line commands

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -368,24 +368,14 @@ fn failure_to_error(
   }
 }
 
-/// 1-based line number where `remaining` begins within `original`. Falls
-/// back to 1 if `remaining` isn't actually a subslice of `original`.
+/// 1-based line number where the parser stopped. Relies on the invariant
+/// that `remaining` is always a suffix of `original` produced by consuming
+/// from the front, so its byte-length gives the offset directly without
+/// any pointer arithmetic — which also handles monch's detached `""`
+/// case (length 0 → offset = end of input).
 fn line_of(original: &str, remaining: &str) -> usize {
-  let line_count = |s: &str| s.bytes().filter(|&b| b == b'\n').count() + 1;
-  // when the failure is at end-of-input, the failure slice may be a
-  // detached `""` (monch's `skip_whitespace` returns the literal `""`
-  // when it consumes all remaining chars), so handle that up-front.
-  if remaining.is_empty() {
-    return line_count(original);
-  }
-  let orig_ptr = original.as_ptr() as usize;
-  let rem_ptr = remaining.as_ptr() as usize;
-  let orig_end = orig_ptr + original.len();
-  if rem_ptr < orig_ptr || rem_ptr > orig_end {
-    return 1;
-  }
-  let offset = rem_ptr - orig_ptr;
-  line_count(&original[..offset])
+  let offset = original.len().saturating_sub(remaining.len());
+  original[..offset].bytes().filter(|&b| b == b'\n').count() + 1
 }
 
 fn parse_sequential_list(input: &str) -> ParseResult<'_, SequentialList> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -320,31 +320,78 @@ pub enum RedirectOpOutput {
 
 pub fn parse(input: &str) -> Result<SequentialList> {
   match parse_sequential_list(input) {
-    Ok((input, expr)) => {
-      if input.trim().is_empty() {
+    Ok((remaining, expr)) => {
+      if remaining.trim().is_empty() {
         if expr.items.is_empty() {
           bail!("Empty command.")
         } else {
           Ok(expr)
         }
       } else {
-        fail_for_trailing_input(input)
-          .into_result()
-          .map_err(|err| err.into())
+        Err(failure_to_error(input, fail_for_trailing_input(remaining)).into())
       }
     }
-    Err(ParseError::Backtrace) => fail_for_trailing_input(input)
-      .into_result()
-      .map_err(|err| err.into()),
-    Err(ParseError::Failure(e)) => e.into_result().map_err(|err| err.into()),
+    Err(ParseError::Backtrace) => {
+      Err(failure_to_error(input, fail_for_trailing_input(input)).into())
+    }
+    Err(ParseError::Failure(e)) => Err(failure_to_error(input, e).into()),
   }
 }
 
+/// Turns a `ParseErrorFailure` into a final `ParseErrorFailureError`.
+///
+/// The code-snippet is clipped to the current line so the error's `~` caret
+/// always points at the correct column, and the message is prefixed with
+/// the 1-based line number when the original input spans multiple lines.
+fn failure_to_error(
+  original: &str,
+  failure: ParseErrorFailure<'_>,
+) -> ParseErrorFailureError {
+  let snippet: String = failure
+    .input
+    .chars()
+    .take_while(|&c| c != '\n' && c != '\r')
+    .take(60)
+    .collect();
+  let message = if original.contains('\n') {
+    format!("{} (line {})", failure.message, line_of(original, failure.input))
+  } else {
+    failure.message
+  };
+  ParseErrorFailureError {
+    message,
+    code_snippet: Some(snippet),
+  }
+}
+
+/// 1-based line number where `remaining` begins within `original`. Falls
+/// back to 1 if `remaining` isn't actually a subslice of `original`.
+fn line_of(original: &str, remaining: &str) -> usize {
+  let line_count =
+    |s: &str| s.bytes().filter(|&b| b == b'\n').count() + 1;
+  // when the failure is at end-of-input, the failure slice may be a
+  // detached `""` (monch's `skip_whitespace` returns the literal `""`
+  // when it consumes all remaining chars), so handle that up-front.
+  if remaining.is_empty() {
+    return line_count(original);
+  }
+  let orig_ptr = original.as_ptr() as usize;
+  let rem_ptr = remaining.as_ptr() as usize;
+  let orig_end = orig_ptr + original.len();
+  if rem_ptr < orig_ptr || rem_ptr > orig_end {
+    return 1;
+  }
+  let offset = rem_ptr - orig_ptr;
+  line_count(&original[..offset])
+}
+
 fn parse_sequential_list(input: &str) -> ParseResult<'_, SequentialList> {
+  // allow blank leading lines (POSIX `linebreak`)
+  let (input, _) = skip_whitespace(input)?;
   let (input, items) = separated_list(
-    terminated(parse_sequential_list_item, skip_whitespace),
+    terminated(parse_sequential_list_item, skip_inline_whitespace),
     terminated(
-      skip_whitespace,
+      skip_inline_whitespace,
       or(
         map(parse_sequential_list_op, |_| ()),
         map(parse_async_list_op, |_| ()),
@@ -373,7 +420,7 @@ fn parse_sequence(input: &str) -> ParseResult<'_, Sequence> {
       parse_shell_var_command,
       map(parse_pipeline, Sequence::Pipeline),
     ),
-    skip_whitespace,
+    skip_inline_whitespace,
   )(input)?;
 
   Ok(match parse_boolean_list_op(input) {
@@ -467,12 +514,12 @@ fn parse_command(input: &str) -> ParseResult<'_, Command> {
       map(parse_subshell, |l| CommandInner::Subshell(Box::new(l))),
       map(parse_simple_command, CommandInner::Simple),
     ),
-    skip_whitespace,
+    skip_inline_whitespace,
   )(input)?;
 
   let before_redirects_input = input;
   let (input, mut redirects) =
-    many0(terminated(parse_redirect, skip_whitespace))(input)?;
+    many0(terminated(parse_redirect, skip_inline_whitespace))(input)?;
 
   if redirects.len() > 1 {
     return ParseError::fail(
@@ -535,7 +582,10 @@ fn parse_boolean_list_op(input: &str) -> ParseResult<'_, BooleanListOperator> {
 }
 
 fn parse_sequential_list_op(input: &str) -> ParseResult<'_, &str> {
-  terminated(tag(";"), skip_whitespace)(input)
+  // `;`, a newline, or a CRLF newline all terminate a command (POSIX
+  // treats `\n` as equivalent to `;`). Any trailing blank lines /
+  // whitespace are then skipped.
+  terminated(or3(tag(";"), tag("\r\n"), tag("\n")), skip_whitespace)(input)
 }
 
 fn parse_async_list_op(input: &str) -> ParseResult<'_, &str> {
@@ -590,7 +640,7 @@ fn parse_redirect(input: &str) -> ParseResult<'_, Redirect> {
   )(input)?;
   let (input, io_file) = or(
     map(preceded(ch('&'), parse_u32), IoFile::Fd),
-    map(preceded(skip_whitespace, parse_word), IoFile::Word),
+    map(preceded(skip_inline_whitespace, parse_word), IoFile::Word),
   )(input)?;
 
   let maybe_fd = if let Some(fd) = maybe_fd {
@@ -612,7 +662,7 @@ fn parse_redirect(input: &str) -> ParseResult<'_, Redirect> {
 }
 
 fn parse_env_vars(input: &str) -> ParseResult<'_, Vec<EnvVar>> {
-  many0(terminated(parse_env_var, skip_whitespace))(input)
+  many0(terminated(parse_env_var, skip_inline_whitespace))(input)
 }
 
 fn parse_env_var(input: &str) -> ParseResult<'_, EnvVar> {
@@ -865,7 +915,16 @@ fn parse_word_parts(
 
     let original_input = input;
     let (input, parts) = many0(or7(
-      or3(
+      or4(
+        // a backslash immediately followed by a newline is a POSIX
+        // line continuation — both characters are consumed and produce
+        // nothing. Applies in unquoted words and inside `"..."`; inside
+        // `'...'` the single-quote parser never reaches this branch so
+        // the characters are preserved, as per POSIX.
+        map(
+          or(tag("\\\r\n"), tag("\\\n")),
+          |_| PendingPart::Parts(Vec::new()),
+        ),
         map(tag("$?"), |_| PendingPart::Variable("?")),
         map(first_escaped_char(mode), PendingPart::Char),
         map(parse_command_substitution, PendingPart::Command),
@@ -1041,7 +1100,9 @@ fn parse_u32(input: &str) -> ParseResult<'_, u32> {
 }
 
 fn assert_whitespace_or_end_and_skip(input: &str) -> ParseResult<'_, ()> {
-  terminated(assert_whitespace_or_end, skip_whitespace)(input)
+  // a newline terminates the command — don't skip it here so that
+  // `parse_sequential_list_op` can pick it up as a separator.
+  terminated(assert_whitespace_or_end, skip_inline_whitespace)(input)
 }
 
 fn assert_whitespace_or_end(input: &str) -> ParseResult<'_, ()> {
@@ -1052,6 +1113,39 @@ fn assert_whitespace_or_end(input: &str) -> ParseResult<'_, ()> {
     return Err(ParseError::Failure(fail_for_trailing_input(input)));
   }
   Ok((input, ()))
+}
+
+/// Like `monch::skip_whitespace`, but stops at `\n` / `\r\n`. A backslash
+/// immediately followed by a newline is consumed as a POSIX line
+/// continuation.
+fn skip_inline_whitespace(input: &str) -> ParseResult<'_, ()> {
+  let bytes = input.as_bytes();
+  let mut i = 0;
+  while i < bytes.len() {
+    match bytes[i] {
+      b' ' | b'\t' => i += 1,
+      b'\\' if bytes.get(i + 1) == Some(&b'\n') => i += 2,
+      b'\\'
+        if bytes.get(i + 1) == Some(&b'\r')
+          && bytes.get(i + 2) == Some(&b'\n') =>
+      {
+        i += 3;
+      }
+      c if !c.is_ascii() => {
+        // any non-ASCII whitespace (U+00A0, etc.) — still skip, but
+        // not `\n` which is ASCII and handled above.
+        let rest = &input[i..];
+        let ch = rest.chars().next().unwrap();
+        if ch.is_whitespace() && ch != '\n' && ch != '\r' {
+          i += ch.len_utf8();
+        } else {
+          break;
+        }
+      }
+      _ => break,
+    }
+  }
+  Ok((&input[i..], ()))
 }
 
 fn is_valid_env_var_char(c: char) -> bool {
@@ -1135,6 +1229,135 @@ mod test {
     assert!(parse("command --arg=\"value\"").is_ok());
     assert!(
       parse("deno run --allow-read=. --allow-write=./testing main.ts").is_ok(),
+    );
+  }
+
+  #[test]
+  fn multi_line_input() {
+    // single-line sanity checks (unchanged)
+    assert_eq!(parse("echo foo").unwrap().items.len(), 1);
+    assert_eq!(parse("echo foo; echo bar").unwrap().items.len(), 2);
+    assert_eq!(parse("echo foo && echo bar").unwrap().items.len(), 1);
+    assert_eq!(parse("echo foo | grep bar").unwrap().items.len(), 1);
+
+    // newline acts as a sequence separator, like `;`
+    assert_eq!(parse("echo foo\necho bar").unwrap().items.len(), 2);
+    // blank lines between commands are skipped
+    assert_eq!(parse("echo foo\n\n\necho bar").unwrap().items.len(), 2);
+    // a trailing newline is ignored
+    assert_eq!(parse("echo foo\n").unwrap().items.len(), 1);
+    // leading blank lines are ignored
+    assert_eq!(parse("\n\necho foo").unwrap().items.len(), 1);
+    // CRLF line endings behave the same as LF
+    assert_eq!(parse("echo foo\r\necho bar").unwrap().items.len(), 2);
+
+    // newlines inside quoted strings are preserved as part of the arg
+    assert_eq!(parse("echo \"hello\nworld\"").unwrap().items.len(), 1);
+    assert_eq!(parse("echo 'hello\nworld'").unwrap().items.len(), 1);
+
+    // after a trailing operator, a newline is a continuation not a terminator
+    assert_eq!(parse("echo foo &&\necho bar").unwrap().items.len(), 1);
+    assert_eq!(parse("echo foo |\ngrep bar").unwrap().items.len(), 1);
+    assert_eq!(parse("echo foo;\necho bar").unwrap().items.len(), 2);
+
+    // newlines inside a subshell act as separators within the subshell
+    assert_eq!(parse("(echo a\necho b)").unwrap().items.len(), 1);
+
+    // multi-command scripts
+    assert_eq!(
+      parse("cd webview\nexport FOO=bar\nmake").unwrap().items.len(),
+      3,
+    );
+
+    // env assignment on its own line is a shell var
+    assert_eq!(parse("FOO=bar\ncmd").unwrap().items.len(), 2);
+  }
+
+  #[test]
+  fn backslash_newline_line_continuation() {
+    // between tokens with a preceding space: the bs+nl is elided
+    assert_eq!(parse("echo hello \\\nworld").unwrap().items.len(), 1);
+    // inside a word (no separator): the two halves are joined into one token
+    assert_eq!(parse("echo hello\\\nworld").unwrap().items.len(), 1);
+    // between command name and first arg: also joined
+    assert_eq!(parse("echo\\\nhello").unwrap().items.len(), 1);
+    // inside double quotes: joined (bash-compatible)
+    assert_eq!(parse("echo \"hello\\\nworld\"").unwrap().items.len(), 1);
+    // inside single quotes: preserved literally (bash-compatible)
+    assert_eq!(parse("echo 'hello\\\nworld'").unwrap().items.len(), 1);
+    // line continuation with a CRLF newline
+    assert_eq!(parse("echo hello\\\r\nworld").unwrap().items.len(), 1);
+    // after a shell var assignment
+    assert_eq!(parse("FOO=bar \\\necho $FOO").unwrap().items.len(), 1);
+  }
+
+  #[test]
+  fn multi_line_error_messages_point_at_the_right_line() {
+    // unclosed double quote on line 2
+    assert_eq!(
+      parse("echo ok\necho \"unclosed").unwrap_err().to_string(),
+      concat!(
+        "Expected closing double quote. (line 2)\n",
+        "  \"unclosed\n",
+        "  ~",
+      ),
+    );
+    // unclosed double quote on line 1
+    assert_eq!(
+      parse("echo \"unclosed\necho ok").unwrap_err().to_string(),
+      concat!(
+        "Expected closing double quote. (line 1)\n",
+        "  \"unclosed\n",
+        "  ~",
+      ),
+    );
+    // bad operator at start of line 2
+    assert_eq!(
+      parse("echo ok\n&& echo bad").unwrap_err().to_string(),
+      concat!(
+        "Unexpected character. (line 2)\n",
+        "  && echo bad\n",
+        "  ~",
+      ),
+    );
+    // unexpected `;` on line 3
+    assert_eq!(
+      parse("echo ok\necho ok\n; foo").unwrap_err().to_string(),
+      concat!("Unexpected character. (line 3)\n", "  ; foo\n", "  ~",),
+    );
+    // trailing `&&` with nothing following
+    assert_eq!(
+      parse("echo ok &&\n").unwrap_err().to_string(),
+      concat!(
+        "Expected command following boolean operator. (line 2)\n",
+        "  \n",
+        "  ~",
+      ),
+    );
+    // unclosed subshell: caret points at the opening `(`
+    assert_eq!(
+      parse("echo ok\n(echo nested\necho more")
+        .unwrap_err()
+        .to_string(),
+      concat!(
+        "Expected closing parenthesis on subshell. (line 2)\n",
+        "  (echo nested\n",
+        "  ~",
+      ),
+    );
+    // unclosed backtick on line 2
+    assert_eq!(
+      parse("echo a\necho `not closed").unwrap_err().to_string(),
+      concat!(
+        "Expected closing backtick. (line 2)\n",
+        "  `not closed\n",
+        "  ~",
+      ),
+    );
+    // single-line input keeps its unchanged message (no `(line N)` suffix)
+    assert_eq!(
+      parse("echo \"unclosed").unwrap_err().to_string(),
+      concat!("Expected closing double quote.\n", "  \"unclosed\n", "  ~",),
     );
   }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -354,7 +354,11 @@ fn failure_to_error(
     .take(60)
     .collect();
   let message = if original.contains('\n') {
-    format!("{} (line {})", failure.message, line_of(original, failure.input))
+    format!(
+      "{} (line {})",
+      failure.message,
+      line_of(original, failure.input)
+    )
   } else {
     failure.message
   };
@@ -367,8 +371,7 @@ fn failure_to_error(
 /// 1-based line number where `remaining` begins within `original`. Falls
 /// back to 1 if `remaining` isn't actually a subslice of `original`.
 fn line_of(original: &str, remaining: &str) -> usize {
-  let line_count =
-    |s: &str| s.bytes().filter(|&b| b == b'\n').count() + 1;
+  let line_count = |s: &str| s.bytes().filter(|&b| b == b'\n').count() + 1;
   // when the failure is at end-of-input, the failure slice may be a
   // detached `""` (monch's `skip_whitespace` returns the literal `""`
   // when it consumes all remaining chars), so handle that up-front.
@@ -921,10 +924,9 @@ fn parse_word_parts(
         // nothing. Applies in unquoted words and inside `"..."`; inside
         // `'...'` the single-quote parser never reaches this branch so
         // the characters are preserved, as per POSIX.
-        map(
-          or(tag("\\\r\n"), tag("\\\n")),
-          |_| PendingPart::Parts(Vec::new()),
-        ),
+        map(or(tag("\\\r\n"), tag("\\\n")), |_| {
+          PendingPart::Parts(Vec::new())
+        }),
         map(tag("$?"), |_| PendingPart::Variable("?")),
         map(first_escaped_char(mode), PendingPart::Char),
         map(parse_command_substitution, PendingPart::Command),
@@ -1265,7 +1267,10 @@ mod test {
 
     // multi-command scripts
     assert_eq!(
-      parse("cd webview\nexport FOO=bar\nmake").unwrap().items.len(),
+      parse("cd webview\nexport FOO=bar\nmake")
+        .unwrap()
+        .items
+        .len(),
       3,
     );
 
@@ -1314,11 +1319,7 @@ mod test {
     // bad operator at start of line 2
     assert_eq!(
       parse("echo ok\n&& echo bad").unwrap_err().to_string(),
-      concat!(
-        "Unexpected character. (line 2)\n",
-        "  && echo bad\n",
-        "  ~",
-      ),
+      concat!("Unexpected character. (line 2)\n", "  && echo bad\n", "  ~",),
     );
     // unexpected `;` on line 3
     assert_eq!(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -18,7 +18,10 @@ pub struct SequentialList {
 #[cfg_attr(feature = "serialization", serde(rename_all = "camelCase"))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SequentialListItem {
+  /// Item ended with `&`.
   pub is_async: bool,
+  /// A `\n` or `\r\n` appeared between this item and the next.
+  pub ends_line: bool,
   pub sequence: Sequence,
 }
 
@@ -338,11 +341,8 @@ pub fn parse(input: &str) -> Result<SequentialList> {
   }
 }
 
-/// Turns a `ParseErrorFailure` into a final `ParseErrorFailureError`.
-///
-/// The code-snippet is clipped to the current line so the error's `~` caret
-/// always points at the correct column, and the message is prefixed with
-/// the 1-based line number when the original input spans multiple lines.
+/// Clips the snippet to the current line and, for multi-line input,
+/// prefixes the message with a 1-based line number.
 fn failure_to_error(
   original: &str,
   failure: ParseErrorFailure<'_>,
@@ -368,43 +368,65 @@ fn failure_to_error(
   }
 }
 
-/// 1-based line number where the parser stopped. Relies on the invariant
-/// that `remaining` is always a suffix of `original` produced by consuming
-/// from the front, so its byte-length gives the offset directly without
-/// any pointer arithmetic — which also handles monch's detached `""`
-/// case (length 0 → offset = end of input).
+/// 1-based line number where the parser stopped.
 fn line_of(original: &str, remaining: &str) -> usize {
   let offset = original.len().saturating_sub(remaining.len());
   original[..offset].bytes().filter(|&b| b == b'\n').count() + 1
 }
 
 fn parse_sequential_list(input: &str) -> ParseResult<'_, SequentialList> {
-  // allow blank leading lines (POSIX `linebreak`)
-  let (input, _) = skip_whitespace(input)?;
-  let (input, items) = separated_list(
-    terminated(parse_sequential_list_item, skip_inline_whitespace),
-    terminated(
-      skip_inline_whitespace,
-      or(
-        map(parse_sequential_list_op, |_| ()),
-        map(parse_async_list_op, |_| ()),
-      ),
-    ),
-  )(input)?;
+  let (mut input, _) = skip_whitespace(input)?;
+  let mut items = Vec::new();
+  while !input.is_empty() {
+    let (after_seq, sequence) = match parse_sequence(input) {
+      Ok(v) => v,
+      Err(ParseError::Backtrace) => break,
+      Err(e) => return Err(e),
+    };
+    let (after_ws, _) = skip_inline_whitespace(after_seq)?;
+    let (after_sep, is_async, ends_line) =
+      match parse_list_item_separator(after_ws) {
+        Ok((rest, (is_async, ends_line))) => (rest, is_async, ends_line),
+        Err(ParseError::Backtrace) => (after_ws, false, false),
+        Err(e) => return Err(e),
+      };
+    let reached_end = after_sep.is_empty() && !is_async && !ends_line;
+    items.push(SequentialListItem {
+      is_async,
+      ends_line,
+      sequence,
+    });
+    input = after_sep;
+    if reached_end {
+      break;
+    }
+  }
   Ok((input, SequentialList { items }))
 }
 
-fn parse_sequential_list_item(
-  input: &str,
-) -> ParseResult<'_, SequentialListItem> {
-  let (input, sequence) = parse_sequence(input)?;
-  Ok((
-    input,
-    SequentialListItem {
-      is_async: maybe(parse_async_list_op)(input)?.1.is_some(),
-      sequence,
-    },
-  ))
+/// Returns `(is_async, ends_line)` for the separator following an item.
+fn parse_list_item_separator(input: &str) -> ParseResult<'_, (bool, bool)> {
+  let mut is_async = false;
+  let mut ends_line = false;
+  let mut cursor = input;
+  // lone `&` (not `&&` or `&|`) — async
+  if let Ok((rest, _)) = terminated(ch('&'), check_not(one_of("|&")))(cursor) {
+    is_async = true;
+    let (rest, _) = skip_inline_whitespace(rest)?;
+    cursor = rest;
+  } else if let Ok((rest, _)) = ch(';')(cursor) {
+    let (rest, _) = skip_inline_whitespace(rest)?;
+    cursor = rest;
+  }
+  if let Ok((rest, _)) = or(tag("\r\n"), tag("\n"))(cursor) {
+    ends_line = true;
+    let (rest, _) = skip_whitespace(rest)?;
+    cursor = rest;
+  }
+  if cursor == input {
+    return ParseError::backtrace();
+  }
+  Ok((cursor, (is_async, ends_line)))
 }
 
 fn parse_sequence(input: &str) -> ParseResult<'_, Sequence> {
@@ -559,7 +581,7 @@ fn parse_shell_arg(input: &str) -> ParseResult<'_, Word> {
 fn parse_list_op(input: &str) -> ParseResult<'_, ()> {
   or(
     map(parse_boolean_list_op, |_| ()),
-    map(or(parse_sequential_list_op, parse_async_list_op), |_| ()),
+    map(parse_list_item_separator, |_| ()),
   )(input)
 }
 
@@ -572,13 +594,6 @@ fn parse_boolean_list_op(input: &str) -> ParseResult<'_, BooleanListOperator> {
       BooleanListOperator::Or
     }),
   )(input)
-}
-
-fn parse_sequential_list_op(input: &str) -> ParseResult<'_, &str> {
-  // `;`, a newline, or a CRLF newline all terminate a command (POSIX
-  // treats `\n` as equivalent to `;`). Any trailing blank lines /
-  // whitespace are then skipped.
-  terminated(or3(tag(";"), tag("\r\n"), tag("\n")), skip_whitespace)(input)
 }
 
 fn parse_async_list_op(input: &str) -> ParseResult<'_, &str> {
@@ -909,11 +924,7 @@ fn parse_word_parts(
     let original_input = input;
     let (input, parts) = many0(or7(
       or4(
-        // a backslash immediately followed by a newline is a POSIX
-        // line continuation — both characters are consumed and produce
-        // nothing. Applies in unquoted words and inside `"..."`; inside
-        // `'...'` the single-quote parser never reaches this branch so
-        // the characters are preserved, as per POSIX.
+        // `\<newline>` line continuation — consumed and erased
         map(or(tag("\\\r\n"), tag("\\\n")), |_| {
           PendingPart::Parts(Vec::new())
         }),
@@ -1092,8 +1103,6 @@ fn parse_u32(input: &str) -> ParseResult<'_, u32> {
 }
 
 fn assert_whitespace_or_end_and_skip(input: &str) -> ParseResult<'_, ()> {
-  // a newline terminates the command — don't skip it here so that
-  // `parse_sequential_list_op` can pick it up as a separator.
   terminated(assert_whitespace_or_end, skip_inline_whitespace)(input)
 }
 
@@ -1107,9 +1116,7 @@ fn assert_whitespace_or_end(input: &str) -> ParseResult<'_, ()> {
   Ok((input, ()))
 }
 
-/// Like `monch::skip_whitespace`, but stops at `\n` / `\r\n`. A backslash
-/// immediately followed by a newline is consumed as a POSIX line
-/// continuation.
+/// Skips space, tab, and `\<newline>` continuations. Leaves raw newlines.
 fn skip_inline_whitespace(input: &str) -> ParseResult<'_, ()> {
   let bytes = input.as_bytes();
   let mut i = 0;
@@ -1124,8 +1131,6 @@ fn skip_inline_whitespace(input: &str) -> ParseResult<'_, ()> {
         i += 3;
       }
       c if !c.is_ascii() => {
-        // any non-ASCII whitespace (U+00A0, etc.) — still skip, but
-        // not `\n` which is ASCII and handled above.
         let rest = &input[i..];
         let ch = rest.chars().next().unwrap();
         if ch.is_whitespace() && ch != '\n' && ch != '\r' {
@@ -1269,6 +1274,38 @@ mod test {
   }
 
   #[test]
+  fn item_separator_flags() {
+    // `;` → sync, same line
+    let list = parse("a; b").unwrap();
+    assert_eq!(list.items.len(), 2);
+    assert!(!list.items[0].is_async && !list.items[0].ends_line);
+
+    // `\n` → sync, new line
+    let list = parse("a\nb").unwrap();
+    assert!(!list.items[0].is_async && list.items[0].ends_line);
+
+    // `&` alone → async, same line
+    let list = parse("a & b").unwrap();
+    assert!(list.items[0].is_async && !list.items[0].ends_line);
+
+    // `&\n` → async AND new line (the case raised earlier)
+    let list = parse("a &\nb").unwrap();
+    assert!(list.items[0].is_async && list.items[0].ends_line);
+
+    // `;\n` → new line dominates (treat like `\n`)
+    let list = parse("a;\nb").unwrap();
+    assert!(!list.items[0].is_async && list.items[0].ends_line);
+
+    // CRLF
+    let list = parse("a\r\nb").unwrap();
+    assert!(!list.items[0].is_async && list.items[0].ends_line);
+
+    // last item is never async / ends_line
+    let list = parse("a; b").unwrap();
+    assert!(!list.items[1].is_async && !list.items[1].ends_line);
+  }
+
+  #[test]
   fn backslash_newline_line_continuation() {
     // between tokens with a preceding space: the bs+nl is elided
     assert_eq!(parse("echo hello \\\nworld").unwrap().items.len(), 1);
@@ -1366,6 +1403,7 @@ mod test {
         items: vec![
           SequentialListItem {
             is_async: false,
+            ends_line: false,
             sequence: Sequence::BooleanList(Box::new(BooleanList {
               current: SimpleCommand {
                 env_vars: vec![
@@ -1389,6 +1427,7 @@ mod test {
           },
           SequentialListItem {
             is_async: true,
+            ends_line: false,
             sequence: Sequence::BooleanList(Box::new(BooleanList {
               current: SimpleCommand {
                 env_vars: vec![],
@@ -1405,6 +1444,7 @@ mod test {
           },
           SequentialListItem {
             is_async: false,
+            ends_line: false,
             sequence: SimpleCommand {
               env_vars: vec![],
               args: vec![Word::new_word("command5")],
@@ -1413,6 +1453,7 @@ mod test {
           },
           SequentialListItem {
             is_async: false,
+            ends_line: false,
             sequence: SimpleCommand {
               env_vars: vec![],
               args: vec![Word::new_word("export"), Word::new_word("ENV6=5")],
@@ -1421,6 +1462,7 @@ mod test {
           },
           SequentialListItem {
             is_async: false,
+            ends_line: false,
             sequence: Sequence::BooleanList(Box::new(BooleanList {
               current: Sequence::ShellVar(EnvVar::new(
                 "ENV7".to_string(),
@@ -1444,6 +1486,7 @@ mod test {
           },
           SequentialListItem {
             is_async: false,
+            ends_line: false,
             sequence: Sequence::BooleanList(Box::new(BooleanList {
               current: SimpleCommand {
                 env_vars: vec![],
@@ -1455,6 +1498,7 @@ mod test {
                 inner: CommandInner::Subshell(Box::new(SequentialList {
                   items: vec![SequentialListItem {
                     is_async: false,
+                    ends_line: false,
                     sequence: Sequence::BooleanList(Box::new(BooleanList {
                       current: SimpleCommand {
                         env_vars: vec![],
@@ -1486,6 +1530,7 @@ mod test {
         items: vec![
           SequentialListItem {
             is_async: false,
+            ends_line: false,
             sequence: SimpleCommand {
               env_vars: vec![],
               args: vec![Word::new_word("command1")],
@@ -1494,6 +1539,7 @@ mod test {
           },
           SequentialListItem {
             is_async: false,
+            ends_line: false,
             sequence: SimpleCommand {
               env_vars: vec![],
               args: vec![Word::new_word("command2")],
@@ -1502,6 +1548,7 @@ mod test {
           },
           SequentialListItem {
             is_async: false,
+            ends_line: false,
             sequence: SimpleCommand {
               env_vars: vec![EnvVar::new(
                 "A".to_string(),
@@ -1527,6 +1574,7 @@ mod test {
       Ok(SequentialList {
         items: vec![SequentialListItem {
           is_async: true,
+          ends_line: false,
           sequence: SimpleCommand {
             env_vars: vec![],
             args: vec![Word::new_word("command")],
@@ -1542,6 +1590,7 @@ mod test {
       Ok(SequentialList {
         items: vec![SequentialListItem {
           is_async: false,
+          ends_line: false,
           sequence: PipeSequence {
             current: SimpleCommand {
               env_vars: vec![],
@@ -1566,6 +1615,7 @@ mod test {
       Ok(SequentialList {
         items: vec![SequentialListItem {
           is_async: false,
+          ends_line: false,
           sequence: PipeSequence {
             current: SimpleCommand {
               env_vars: vec![],
@@ -1598,6 +1648,7 @@ mod test {
       Ok(SequentialList {
         items: vec![SequentialListItem {
           is_async: false,
+          ends_line: false,
           sequence: SimpleCommand {
             env_vars: vec![],
             args: vec![
@@ -1616,6 +1667,7 @@ mod test {
       Ok(SequentialList {
         items: vec![SequentialListItem {
           is_async: false,
+          ends_line: false,
           sequence: Sequence::BooleanList(Box::new(BooleanList {
             current: Pipeline {
               negated: true,
@@ -1691,6 +1743,7 @@ mod test {
         value: Word(vec![WordPart::Command(SequentialList {
           items: vec![SequentialListItem {
             is_async: false,
+            ends_line: false,
             sequence: SimpleCommand {
               env_vars: vec![],
               args: vec![Word::new_word("test")],
@@ -1709,6 +1762,7 @@ mod test {
         value: Word(vec![WordPart::Command(SequentialList {
           items: vec![SequentialListItem {
             is_async: false,
+            ends_line: false,
             sequence: Sequence::ShellVar(EnvVar {
               name: "OTHER".to_string(),
               value: Word::new_word("5"),
@@ -1820,6 +1874,7 @@ mod test {
         WordPart::Command(SequentialList {
           items: Vec::from([SequentialListItem {
             is_async: false,
+            ends_line: false,
             sequence: Sequence::Pipeline(Pipeline {
               negated: false,
               inner: PipelineInner::Command(Command {
@@ -1840,6 +1895,7 @@ mod test {
         WordPart::Command(SequentialList {
           items: Vec::from([SequentialListItem {
             is_async: false,
+            ends_line: false,
             sequence: Sequence::Pipeline(Pipeline {
               negated: false,
               inner: PipelineInner::Command(Command {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -322,6 +322,38 @@ pub enum RedirectOpOutput {
 }
 
 pub fn parse(input: &str) -> Result<SequentialList> {
+  /// Clips the snippet to the current line and, for multi-line input,
+  /// prefixes the message with a 1-based line number.
+  fn failure_to_error(
+    original: &str,
+    failure: ParseErrorFailure<'_>,
+  ) -> ParseErrorFailureError {
+    fn line_of(original: &str, remaining: &str) -> usize {
+      let offset = original.len().saturating_sub(remaining.len());
+      original[..offset].bytes().filter(|&b| b == b'\n').count() + 1
+    }
+
+    let snippet: String = failure
+      .input
+      .chars()
+      .take_while(|&c| c != '\n' && c != '\r')
+      .take(60)
+      .collect();
+    let message = if original.contains('\n') {
+      format!(
+        "{} (line {})",
+        failure.message,
+        line_of(original, failure.input)
+      )
+    } else {
+      failure.message
+    };
+    ParseErrorFailureError {
+      message,
+      code_snippet: Some(snippet),
+    }
+  }
+
   match parse_sequential_list(input) {
     Ok((remaining, expr)) => {
       if remaining.trim().is_empty() {
@@ -339,39 +371,6 @@ pub fn parse(input: &str) -> Result<SequentialList> {
     }
     Err(ParseError::Failure(e)) => Err(failure_to_error(input, e).into()),
   }
-}
-
-/// Clips the snippet to the current line and, for multi-line input,
-/// prefixes the message with a 1-based line number.
-fn failure_to_error(
-  original: &str,
-  failure: ParseErrorFailure<'_>,
-) -> ParseErrorFailureError {
-  let snippet: String = failure
-    .input
-    .chars()
-    .take_while(|&c| c != '\n' && c != '\r')
-    .take(60)
-    .collect();
-  let message = if original.contains('\n') {
-    format!(
-      "{} (line {})",
-      failure.message,
-      line_of(original, failure.input)
-    )
-  } else {
-    failure.message
-  };
-  ParseErrorFailureError {
-    message,
-    code_snippet: Some(snippet),
-  }
-}
-
-/// 1-based line number where the parser stopped.
-fn line_of(original: &str, remaining: &str) -> usize {
-  let offset = original.len().saturating_sub(remaining.len());
-  original[..offset].bytes().filter(|&b| b == b'\n').count() + 1
 }
 
 fn parse_sequential_list(input: &str) -> ParseResult<'_, SequentialList> {
@@ -1250,6 +1249,7 @@ mod test {
 
     // after a trailing operator, a newline is a continuation not a terminator
     assert_eq!(parse("echo foo &&\necho bar").unwrap().items.len(), 1);
+    assert_eq!(parse("false ||\necho fallback").unwrap().items.len(), 1);
     assert_eq!(parse("echo foo |\ngrep bar").unwrap().items.len(), 1);
     assert_eq!(parse("echo foo;\necho bar").unwrap().items.len(), 2);
 
@@ -1317,6 +1317,23 @@ mod test {
     assert_eq!(parse("echo hello\\\r\nworld").unwrap().items.len(), 1);
     // after a shell var assignment
     assert_eq!(parse("FOO=bar \\\necho $FOO").unwrap().items.len(), 1);
+    // trailing `\` at EOF is a literal backslash, not a continuation (bash-compatible)
+    let list = parse("echo hello\\").unwrap();
+    assert_eq!(list.items.len(), 1);
+    let Sequence::Pipeline(pipeline) = &list.items[0].sequence else {
+      panic!("expected pipeline");
+    };
+    let PipelineInner::Command(cmd) = &pipeline.inner else {
+      panic!("expected command");
+    };
+    let CommandInner::Simple(simple) = &cmd.inner else {
+      panic!("expected simple command");
+    };
+    assert_eq!(simple.args.len(), 2);
+    assert_eq!(
+      simple.args[1].parts(),
+      &vec![WordPart::Text("hello\\".to_string())],
+    );
   }
 
   #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2149,6 +2149,7 @@ mod test {
       serialize_to_json("./example > output.txt"),
       serde_json::json!({
         "items": [{
+          "endsLine": false,
           "isAsync": false,
           "sequence": {
             "inner": {
@@ -2186,6 +2187,7 @@ mod test {
       serialize_to_json("./example 2> output.txt"),
       serde_json::json!({
         "items": [{
+          "endsLine": false,
           "isAsync": false,
           "sequence": {
             "inner": {
@@ -2226,6 +2228,7 @@ mod test {
       serialize_to_json("./example &> output.txt"),
       serde_json::json!({
         "items": [{
+          "endsLine": false,
           "isAsync": false,
           "sequence": {
             "inner": {
@@ -2265,6 +2268,7 @@ mod test {
       serialize_to_json("./example < output.txt"),
       serde_json::json!({
         "items": [{
+          "endsLine": false,
           "isAsync": false,
           "sequence": {
             "inner": {
@@ -2303,6 +2307,7 @@ mod test {
       serialize_to_json("./example <&0"),
       serde_json::json!({
         "items": [{
+          "endsLine": false,
           "isAsync": false,
           "sequence": {
             "inner": {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -596,10 +596,6 @@ fn parse_boolean_list_op(input: &str) -> ParseResult<'_, BooleanListOperator> {
   )(input)
 }
 
-fn parse_async_list_op(input: &str) -> ParseResult<'_, &str> {
-  parse_op_str("&")(input)
-}
-
 fn parse_negated_op(input: &str) -> ParseResult<'_, &str> {
   terminated(
     tag("!"),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2063,3 +2063,48 @@ async fn pipefail_with_sigpipe() {
     .run()
     .await;
 }
+
+#[tokio::test]
+async fn multi_line_commands() {
+  // newline separates commands, like `;`
+  TestBuilder::new()
+    .command("echo one\necho two\necho three")
+    .assert_stdout("one\ntwo\nthree\n")
+    .run()
+    .await;
+
+  // blank lines are ignored
+  TestBuilder::new()
+    .command("\n\necho foo\n\necho bar\n")
+    .assert_stdout("foo\nbar\n")
+    .run()
+    .await;
+
+  // newline after `&&` is a continuation
+  TestBuilder::new()
+    .command("echo foo &&\n  echo bar")
+    .assert_stdout("foo\nbar\n")
+    .run()
+    .await;
+
+  // newline after `|` is a continuation
+  TestBuilder::new()
+    .command("echo hello |\n  cat")
+    .assert_stdout("hello\n")
+    .run()
+    .await;
+
+  // env assignment on its own line sets a shell var for later lines
+  TestBuilder::new()
+    .command("FOO=bar\necho $FOO")
+    .assert_stdout("bar\n")
+    .run()
+    .await;
+
+  // CRLF line endings work
+  TestBuilder::new()
+    .command("echo one\r\necho two")
+    .assert_stdout("one\ntwo\n")
+    .run()
+    .await;
+}


### PR DESCRIPTION
This is breaking because we previously treated newlines as just whitespace.

Part of https://github.com/dsherret/dax/issues/303