### PR TITLE
feat: add POSIX null command `:` as a builtin

### DIFF
--- a/src/shell/commands/mod.rs
+++ b/src/shell/commands/mod.rs
@@ -98,6 +98,12 @@ pub fn builtin_commands() -> HashMap<String, Rc<dyn ShellCommand>> {
       "false".to_string(),
       Rc::new(ExitCodeCommand(1)) as Rc<dyn ShellCommand>,
     ),
+    // POSIX null command: discards its arguments and always exits 0.
+    // Commonly seen as `"test": ":"` in package.json no-op scripts.
+    (
+      ":".to_string(),
+      Rc::new(ExitCodeCommand(0)) as Rc<dyn ShellCommand>,
+    ),
     (
       "unset".to_string(),
       Rc::new(unset::UnsetCommand) as Rc<dyn ShellCommand>,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -155,6 +155,24 @@ async fn boolean_logic() {
 }
 
 #[tokio::test]
+async fn null_command() {
+  // POSIX `:` is the null command — always succeeds, discards args.
+  TestBuilder::new().command(":").run().await;
+
+  TestBuilder::new()
+    .command(": ignored args && echo ok")
+    .assert_stdout("ok\n")
+    .run()
+    .await;
+
+  TestBuilder::new()
+    .command(": && echo yes || echo no")
+    .assert_stdout("yes\n")
+    .run()
+    .await;
+}
+
+#[tokio::test]
 async fn exit() {
   TestBuilder::new()
     .command("exit 1")


### PR DESCRIPTION
`:` is POSIX's null command: it discards its arguments and always
exits 0. Bash treats it as a builtin. We had `true` and `false`
already; add `:` alongside them (same `ExitCodeCommand(0)` underneath).

Without this, `deno task` for a `package.json` script defined as
`"test": ":"` (a common no-op pattern, e.g. used in the aube benchmark
fixture at https://aube.en.dev/benchmarks.html on a ~1400-package
project) fails with `:: command not found` and exit code 127, while
bash / sh / dash all return 0 cleanly. As a result the benchmark's
`install-test` scenario for Deno can never complete.

Adds an integration test covering the bare `:`, argument discarding,
and `&&` / `||` short-circuit behavior.