### PR TITLE
feat: support redirects in pipe sequence commands

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -490,7 +490,6 @@ fn parse_pipeline(input: &str) -> ParseResult<'_, Pipeline> {
 }
 
 fn parse_pipeline_inner(input: &str) -> ParseResult<'_, PipelineInner> {
-  let original_input = input;
   let (input, command) = parse_command(input)?;
 
   let (input, inner) = match parse_pipe_sequence_op(input) {
@@ -499,13 +498,6 @@ fn parse_pipeline_inner(input: &str) -> ParseResult<'_, PipelineInner> {
         &parse_pipeline_inner,
         "Expected command following pipeline operator.",
       )(input)?;
-
-      if command.redirect.is_some() {
-        return ParseError::fail(
-          original_input,
-          "Redirects in pipe sequence commands are currently not supported.",
-        );
-      }
 
       (
         input,
@@ -2154,12 +2146,60 @@ mod test {
       "1> stdout.txt 2> stderr.txt",
     );
 
-    // redirect in pipeline sequence command should error
-    run_test_with_end(
+    // redirect on the left side of a pipe sequence
+    run_test(
       parse_sequence,
       "echo 1 1> stdout.txt | cat",
-      Err("Redirects in pipe sequence commands are currently not supported."),
-      "echo 1 1> stdout.txt | cat",
+      Ok(
+        PipeSequence {
+          current: Command {
+            inner: CommandInner::Simple(SimpleCommand {
+              env_vars: vec![],
+              args: vec![Word::new_word("echo"), Word::new_word("1")],
+            }),
+            redirect: Some(Redirect {
+              maybe_fd: Some(RedirectFd::Fd(1)),
+              op: RedirectOp::Output(RedirectOpOutput::Overwrite),
+              io_file: IoFile::Word(Word::new_word("stdout.txt")),
+            }),
+          },
+          op: PipeSequenceOperator::Stdout,
+          next: SimpleCommand {
+            env_vars: vec![],
+            args: vec![Word::new_word("cat")],
+          }
+          .into(),
+        }
+        .into(),
+      ),
+    );
+
+    // `2>&1 | tee` — the use case from denoland/deno#28808
+    run_test(
+      parse_sequence,
+      "cmd 2>&1 | tee log",
+      Ok(
+        PipeSequence {
+          current: Command {
+            inner: CommandInner::Simple(SimpleCommand {
+              env_vars: vec![],
+              args: vec![Word::new_word("cmd")],
+            }),
+            redirect: Some(Redirect {
+              maybe_fd: Some(RedirectFd::Fd(2)),
+              op: RedirectOp::Output(RedirectOpOutput::Overwrite),
+              io_file: IoFile::Fd(1),
+            }),
+          },
+          op: PipeSequenceOperator::Stdout,
+          next: SimpleCommand {
+            env_vars: vec![],
+            args: vec![Word::new_word("tee"), Word::new_word("log")],
+          }
+          .into(),
+        }
+        .into(),
+      ),
     );
   }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -535,6 +535,24 @@ async fn pipeline() {
     .assert_file_equals("output.txt", "1\n")
     .run()
     .await;
+
+  // redirect on the left side of a pipe: the left command's stdout goes to the
+  // file, so the right side of the pipe receives nothing.
+  TestBuilder::new()
+    .command(r#"echo 1 > output.txt | deno eval 'const s = await new Response(Deno.stdin.readable).text(); console.log("len=" + s.length)'"#)
+    .assert_file_equals("output.txt", "1\n")
+    .assert_stdout("len=0\n")
+    .run()
+    .await;
+
+  // `2>&1 | reader` — both stdout and stderr of the left command are
+  // funneled through the pipe to the reader. This is the use case from
+  // denoland/deno#28808.
+  TestBuilder::new()
+    .command(r#"deno eval 'console.log("o"); console.error("e")' 2>&1 | deno eval 'await Deno.stdin.readable.pipeTo(Deno.stdout.writable)'"#)
+    .assert_stdout("o\ne\n")
+    .run()
+    .await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
The parser previously rejected redirects on any command in a pipe
sequence (e.g. `cmd 2>&1 | tee log`), even though the AST's `Command`
node already carries a per-command `redirect` and the executor's
`execute_command` applies it before dispatching to `execute_simple_command`
/ `execute_subshell`. Drop the parser bailout in `parse_pipeline_inner`
so common bash idioms like `cmd 2>&1 | reader` and `cmd > file | reader`
parse and execute.

The existing negative parser test that asserted the error message is
replaced with two positive parser tests covering `echo 1 1> stdout.txt
| cat` and `cmd 2>&1 | tee log`. Two integration tests exercise the
runtime behavior end-to-end: that the left side's stdout redirect makes
the right side receive an empty pipe, and that `2>&1 |` correctly
funnels both stdout and stderr into the pipe.

Fixes denoland/deno#28808.