### PR TITLE
fix: pass malformed glob patterns through literally

### DIFF
--- a/src/shell/execute.rs
+++ b/src/shell/execute.rs
@@ -933,7 +933,17 @@ fn evaluate_word_parts(
             Ok(paths)
           }
         }
-        Err(err) => Err(EvaluateWordTextError::InvalidPattern { pattern, err }),
+        Err(err) => {
+          // bash passes malformed patterns through literally; only error when
+          // failglob is explicitly set
+          if options.contains(ShellOptions::FAILGLOB) {
+            Err(EvaluateWordTextError::InvalidPattern { pattern, err })
+          } else if options.contains(ShellOptions::NULLGLOB) {
+            Ok(Vec::new())
+          } else {
+            Ok(vec![current_text.into()])
+          }
+        }
       }
     } else {
       Ok(vec![text_parts_to_string(text_parts)])

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1509,6 +1509,27 @@ async fn glob_basic() {
     .assert_exit_code(0)
     .run()
     .await;
+
+  // denoland/deno#27238: a glob inside a non-path argument like a flag value
+  // should pass through literally rather than erroring.
+  TestBuilder::new()
+    .command("echo --allow-write=@mizu/**/README.md,README.md")
+    .assert_stderr("")
+    .assert_stdout("--allow-write=@mizu/**/README.md,README.md\n")
+    .assert_exit_code(0)
+    .run()
+    .await;
+
+  // Same issue, malformed-pattern form: `**` not in its own path component.
+  // The glob crate rejects the pattern; without failglob we should still
+  // fall through to the literal text.
+  TestBuilder::new()
+    .command("echo --allow-write=**/*.txt")
+    .assert_stderr("")
+    .assert_stdout("--allow-write=**/*.txt\n")
+    .assert_exit_code(0)
+    .run()
+    .await;
 }
 
 #[tokio::test]
@@ -1920,6 +1941,17 @@ async fn shopt_failglob() {
     .file("test.txt", "test\n")
     .command("shopt -u failglob && shopt -u nullglob && echo *.nonexistent")
     .assert_stdout("*.nonexistent\n")
+    .assert_exit_code(0)
+    .run()
+    .await;
+
+  // failglob on with a malformed pattern still errors (exit code 1)
+  TestBuilder::new()
+    .command(
+      "shopt -s failglob && echo --allow-write=**/*.txt 2> /dev/null || echo recovered",
+    )
+    .assert_stderr("")
+    .assert_stdout("recovered\n")
     .assert_exit_code(0)
     .run()
     .await;


### PR DESCRIPTION
A task command like `deno run --allow-write=**/*.txt test.ts` failed with
`glob: no matches found ... Pattern syntax error near position N: recursive
wildcards must form a single path component` because the `**` does not form
its own path component once joined to the `--allow-write=` prefix. The glob
crate rejects the pattern at compile time, and the `Err` arm of the match in
`evaluate_word_text` errored unconditionally — it did not consult
`failglob` / `nullglob` the way the empty-match arm does.

Bash's behavior is to pass a malformed pattern through literally unless
`failglob` is explicitly set. This change mirrors the empty-match branch
into the pattern-error branch so the default is literal pass-through, with
`failglob` and `nullglob` still respected. Includes regression tests for
both flavors from the issue (the valid-but-zero-match form and the
malformed-pattern form), plus a `failglob`-on case confirming the new
branch still errors when requested.

Fixes denoland/deno#27238