### PR TITLE
feat: support shell-style `#` comments

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -377,7 +377,7 @@ pub fn parse(input: &str) -> Result<SequentialList, ParseErrorFailureError> {
 }
 
 fn parse_sequential_list(input: &str) -> ParseResult<'_, SequentialList> {
-  let (mut input, _) = skip_whitespace(input)?;
+  let (mut input, _) = skip_whitespace_and_comments(input)?;
   let mut items = Vec::new();
   while !input.is_empty() {
     let (after_seq, sequence) = match parse_sequence(input) {
@@ -422,7 +422,7 @@ fn parse_list_item_separator(input: &str) -> ParseResult<'_, (bool, bool)> {
   }
   if let Ok((rest, _)) = or(tag("\r\n"), tag("\n"))(cursor) {
     ends_line = true;
-    let (rest, _) = skip_whitespace(rest)?;
+    let (rest, _) = skip_whitespace_and_comments(rest)?;
     cursor = rest;
   }
   if cursor == input {
@@ -604,7 +604,7 @@ fn parse_op_str<'a>(
   debug_assert!(operator == "&&" || operator == "||" || operator == "&");
   terminated(
     tag(operator),
-    terminated(check_not(one_of("|&")), skip_whitespace),
+    terminated(check_not(one_of("|&")), skip_whitespace_and_comments),
   )
 }
 
@@ -616,7 +616,7 @@ fn parse_pipe_sequence_op(
       map(tag("|&"), |_| PipeSequenceOperator::StdoutStderr),
       map(ch('|'), |_| PipeSequenceOperator::Stdout),
     ),
-    terminated(check_not(one_of("|&")), skip_whitespace),
+    terminated(check_not(one_of("|&")), skip_whitespace_and_comments),
   )(input)
 }
 
@@ -1268,7 +1268,7 @@ fn parse_backticks_command_substitution(
 
 fn parse_subshell(input: &str) -> ParseResult<'_, SequentialList> {
   delimited(
-    terminated(ch('('), skip_whitespace),
+    terminated(ch('('), skip_whitespace_and_comments),
     parse_sequential_list,
     with_failure_input(
       input,
@@ -1316,7 +1316,9 @@ fn assert_whitespace_or_end(input: &str) -> ParseResult<'_, ()> {
   Ok((input, ()))
 }
 
-/// Skips space, tab, and `\<newline>` continuations. Leaves raw newlines.
+/// Skips space, tab, and `\<newline>` continuations, plus a trailing
+/// `#`-comment if one begins at the resulting word boundary. Leaves raw
+/// newlines (a comment runs to, but does not consume, the next newline).
 fn skip_inline_whitespace(input: &str) -> ParseResult<'_, ()> {
   let bytes = input.as_bytes();
   let mut i = 0;
@@ -1342,7 +1344,38 @@ fn skip_inline_whitespace(input: &str) -> ParseResult<'_, ()> {
       _ => break,
     }
   }
-  Ok((&input[i..], ()))
+  Ok((skip_comment(&input[i..]), ()))
+}
+
+/// If `input` starts with a `#`, consume the comment up to (but not
+/// including) the next newline. Otherwise return `input` unchanged.
+///
+/// Callers must invoke this only at a word boundary (after skipping
+/// whitespace or following a metacharacter); a `#` in the middle of a
+/// word is an ordinary character, not a comment.
+fn skip_comment(input: &str) -> &str {
+  if input.starts_with('#') {
+    let end = input.find(['\n', '\r']).unwrap_or(input.len());
+    &input[end..]
+  } else {
+    input
+  }
+}
+
+/// Skips whitespace (including newlines) and any whole-line `#`-comments,
+/// repeating until neither remains. Mirrors `skip_whitespace` but is
+/// comment-aware, so it can be used both as `skip_whitespace_and_comments(input)?`
+/// and as a combinator (e.g. `terminated(op, skip_whitespace_and_comments)`).
+fn skip_whitespace_and_comments(input: &str) -> ParseResult<'_, ()> {
+  let mut current = input;
+  loop {
+    let (rest, _) = skip_whitespace(current)?;
+    let rest = skip_comment(rest);
+    if rest == current {
+      return Ok((current, ()));
+    }
+    current = rest;
+  }
 }
 
 fn is_valid_env_var_byte(b: u8) -> bool {
@@ -1472,6 +1505,92 @@ mod test {
 
     // env assignment on its own line is a shell var
     assert_eq!(parse("FOO=bar\ncmd").unwrap().items.len(), 2);
+  }
+
+  #[test]
+  fn comments() {
+    fn single_command_args(input: &str) -> Vec<Word> {
+      let list = parse(input).unwrap();
+      assert_eq!(list.items.len(), 1, "input: {input:?}");
+      let Sequence::Pipeline(pipeline) = &list.items[0].sequence else {
+        panic!("expected pipeline for input: {input:?}");
+      };
+      let PipelineInner::Command(cmd) = &pipeline.inner else {
+        panic!("expected command for input: {input:?}");
+      };
+      let CommandInner::Simple(simple) = &cmd.inner else {
+        panic!("expected simple command for input: {input:?}");
+      };
+      simple.args.clone()
+    }
+
+    // trailing comment after a command (the case from denoland/deno#27644)
+    assert_eq!(
+      single_command_args("echo foo # this is a comment"),
+      vec![Word::new_word("echo"), Word::new_word("foo")],
+    );
+    // no space before `#` is still a comment at a word boundary
+    assert_eq!(
+      single_command_args("echo foo #comment"),
+      vec![Word::new_word("echo"), Word::new_word("foo")],
+    );
+    // `#` in the middle of a word is a literal character, not a comment
+    assert_eq!(
+      single_command_args("echo foo#bar"),
+      vec![Word::new_word("echo"), Word::new_word("foo#bar")],
+    );
+    // `#` attached to the start of a word (no preceding space) is literal
+    assert_eq!(
+      single_command_args("echo #foo"),
+      vec![Word::new_word("echo")],
+    );
+    // `#` inside quotes is literal
+    assert_eq!(
+      single_command_args("echo '# not a comment'"),
+      vec![Word::new_word("echo"), Word::new_string("# not a comment"),],
+    );
+    assert_eq!(
+      single_command_args("echo \"# not a comment\""),
+      vec![Word::new_word("echo"), Word::new_string("# not a comment"),],
+    );
+
+    // a comment line between commands is skipped
+    assert_eq!(
+      parse("echo foo\n# a comment\necho bar")
+        .unwrap()
+        .items
+        .len(),
+      2,
+    );
+    // a leading comment line is skipped
+    assert_eq!(parse("# leading comment\necho foo").unwrap().items.len(), 1);
+    // a trailing comment line is skipped
+    assert_eq!(parse("echo foo\n# trailing").unwrap().items.len(), 1);
+    // a comment after `;`
+    assert_eq!(
+      parse("echo foo ;# comment\necho bar").unwrap().items.len(),
+      2
+    );
+    // a comment following a boolean operator continuation
+    assert_eq!(
+      parse("echo foo && # comment\necho bar")
+        .unwrap()
+        .items
+        .len(),
+      1,
+    );
+    // a comment following a pipe continuation
+    assert_eq!(
+      parse("echo foo | # comment\ngrep bar").unwrap().items.len(),
+      1,
+    );
+    // a comment line inside a subshell is skipped
+    assert_eq!(parse("(echo a\n# comment\necho b)").unwrap().items.len(), 1);
+    // a comment-only input is an empty command
+    assert_eq!(
+      parse("# just a comment").err().unwrap().to_string(),
+      "Empty command.",
+    );
   }
 
   #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -628,6 +628,7 @@ fn parse_redirect(input: &str) -> ParseResult<'_, Redirect> {
   } else {
     (input, None)
   };
+  let redirect_op_input = input;
   let (input, op) = or3(
     map(tag(">>"), |_| RedirectOp::Output(RedirectOpOutput::Append)),
     map(or(tag(">"), tag(">|")), |_| {
@@ -639,6 +640,15 @@ fn parse_redirect(input: &str) -> ParseResult<'_, Redirect> {
     map(preceded(ch('&'), parse_u32), IoFile::Fd),
     map(preceded(skip_inline_whitespace, parse_word), IoFile::Word),
   )(input)?;
+
+  // A redirect operator must be followed by a target. An empty word here
+  // means the path was missing (e.g. `cmd >` at end of input, or a comment
+  // beginning right after the operator as in `cmd > # comment`).
+  if let IoFile::Word(word) = &io_file
+    && word.parts().is_empty()
+  {
+    return ParseError::fail(redirect_op_input, "Expected redirect path.");
+  }
 
   let maybe_fd = if let Some(fd) = maybe_fd {
     Some(RedirectFd::Fd(fd))
@@ -1593,6 +1603,27 @@ mod test {
       parse("# just a comment").err().unwrap().to_string(),
       "Empty command.",
     );
+    // a comment right after a redirect operator leaves no path: error
+    assert_eq!(
+      parse("echo foo > # comment").err().unwrap().to_string(),
+      concat!("Expected redirect path.\n", "  > # comment\n", "  ~"),
+    );
+  }
+
+  #[test]
+  fn redirect_missing_path_is_error() {
+    // a redirect operator with no following path is a parse error,
+    // not a redirect to an empty target
+    assert_eq!(
+      parse("echo foo >").err().unwrap().to_string(),
+      concat!("Expected redirect path.\n", "  >\n", "  ~"),
+    );
+    assert_eq!(
+      parse("cat <").err().unwrap().to_string(),
+      concat!("Expected redirect path.\n", "  <\n", "  ~"),
+    );
+    // still parses normally with a path
+    assert_eq!(parse("echo foo > out").unwrap().items.len(), 1);
   }
 
   #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -631,7 +631,10 @@ fn parse_redirect(input: &str) -> ParseResult<'_, Redirect> {
   let redirect_op_input = input;
   let (input, op) = or3(
     map(tag(">>"), |_| RedirectOp::Output(RedirectOpOutput::Append)),
-    map(or(tag(">"), tag(">|")), |_| {
+    // `>|` (clobber) must be tried before `>`, otherwise `>` matches the
+    // prefix and the `|` is left to be misparsed as a pipe. We don't model
+    // `noclobber`, so `>|` is treated the same as `>` (overwrite).
+    map(or(tag(">|"), tag(">")), |_| {
       RedirectOp::Output(RedirectOpOutput::Overwrite)
     }),
     map(ch('<'), |_| RedirectOp::Input(RedirectOpInput::Redirect)),
@@ -2539,6 +2542,11 @@ mod test {
         }),
       }),
     );
+
+    // clobber (`>|`) is treated as overwrite; the `>|` must win over `>`
+    // so the `|` isn't left behind and misparsed as a pipe
+    run_test(parse_command, r#"echo 1 >| test.txt"#, expected.clone());
+    run_test(parse_command, r#"echo 1 >|test.txt"#, expected.clone());
 
     // output redirect to fd
     run_test(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1371,7 +1371,9 @@ fn skip_whitespace_and_comments(input: &str) -> ParseResult<'_, ()> {
   loop {
     let (rest, _) = skip_whitespace(current)?;
     let rest = skip_comment(rest);
-    if rest == current {
+    // `rest` is always a suffix of `current`, so equal lengths means
+    // nothing was consumed — compare lengths to avoid a byte-wise compare.
+    if rest.len() == current.len() {
       return Ok((current, ()));
     }
     current = rest;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -15,6 +15,51 @@ mod test_builder;
 const FOLDER_SEPERATOR: char = if cfg!(windows) { '\\' } else { '/' };
 
 #[tokio::test]
+async fn comments() {
+  // trailing comment after a command (denoland/deno#27644)
+  TestBuilder::new()
+    .command("echo foo # this is a comment")
+    .assert_stdout("foo\n")
+    .run()
+    .await;
+
+  // `#` with no preceding space is still a comment at a word boundary
+  TestBuilder::new()
+    .command("echo foo #comment")
+    .assert_stdout("foo\n")
+    .run()
+    .await;
+
+  // `#` in the middle of a word is a literal character, not a comment
+  TestBuilder::new()
+    .command("echo foo#bar")
+    .assert_stdout("foo#bar\n")
+    .run()
+    .await;
+
+  // `#` inside quotes is literal
+  TestBuilder::new()
+    .command("echo '# not a comment'")
+    .assert_stdout("# not a comment\n")
+    .run()
+    .await;
+
+  // comment lines interspersed with commands
+  TestBuilder::new()
+    .command("# leading\necho foo\n# middle\necho bar\n# trailing")
+    .assert_stdout("foo\nbar\n")
+    .run()
+    .await;
+
+  // comment after a `&&` continuation
+  TestBuilder::new()
+    .command("echo foo && # comment\necho bar")
+    .assert_stdout("foo\nbar\n")
+    .run()
+    .await;
+}
+
+#[tokio::test]
 async fn commands() {
   TestBuilder::new()
     .command("echo 1")


### PR DESCRIPTION
Implements shell-style `#` comments in task commands, requested in
denoland/deno#27644. Previously a command like `echo foo # comment`
executed the entire string literally instead of stopping at `#`.

A `#` now begins a comment wherever a shell would recognize one: at the
start of a line or command, or following whitespace or a metacharacter.
Everything from the `#` to the end of the line is ignored. A `#` in the
middle of a word (`foo#bar`) or inside single/double quotes (`'# x'`,
`"# x"`) stays a literal character, so existing commands are unaffected.

The implementation keeps comment handling at the parser's existing word
boundaries. `skip_inline_whitespace` now also consumes a trailing
`#`-comment up to the next newline, and a new comment-aware
`skip_whitespace_and_comments` replaces the plain whitespace skip at the
remaining boundary positions: the start of a sequential list, after a
newline separator, after `&&`/`||`, after `|`/`|&`, and at the start of a
subshell. This covers trailing comments, whole comment lines interspersed
with commands, and comments following operator continuations and inside
subshells.

Note the `\#` "Unsupported reserved word" error mentioned in the issue no
longer applies, since real comment support removes the need to escape
`#`.

While adding comment support surfaced two adjacent redirect-parsing bugs,
both are fixed here:

- A redirect operator with no following target (`echo foo >`, `cat <`, or
  a comment beginning right after the operator as in `echo foo > #c`) now
  fails with `Expected redirect path.` instead of silently producing a
  redirect with an empty target word that only errored later at runtime.
- `>|` (clobber) now parses. The `or(tag(">"), tag(">|"))` ordering let
  `>` match the prefix first, leaving the `|` to be misparsed as a pipe;
  `>|` is now tried first and, since noclobber is not modeled, behaves
  identically to `>`.

Tests are added at both layers: parser unit tests asserting the parsed
AST for each case (comments, the missing-path error, and `>|`), and an
integration test verifying end-to-end stdout for the comment cases.
